### PR TITLE
회원 관리 모달 CSS 충돌 수정 및 주요 화면 스코프 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tests/e2e/reports/
 # local env files
 .env.local
 .env.*.local
+.omc/
 
 # dependencies
 /node_modules

--- a/react_web_app/.gitignore
+++ b/react_web_app/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/react_web_app/.gitignore
+++ b/react_web_app/.gitignore
@@ -13,10 +13,12 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
+.omc/
 
 npm-debug.log*
 yarn-debug.log*

--- a/react_web_app/craco.config.js
+++ b/react_web_app/craco.config.js
@@ -1,0 +1,45 @@
+module.exports = {
+  webpack: {
+    configure: (webpackConfig) => {
+      const sourceMapRule = webpackConfig.module.rules.find(
+        (rule) =>
+          rule.enforce === 'pre' &&
+          (
+            (typeof rule.loader === 'string' && rule.loader.includes('source-map-loader')) ||
+            (
+              Array.isArray(rule.use) &&
+              rule.use.some(
+                (useEntry) =>
+                  typeof useEntry === 'object' &&
+                  useEntry !== null &&
+                  'loader' in useEntry &&
+                  typeof useEntry.loader === 'string' &&
+                  useEntry.loader.includes('source-map-loader')
+              )
+            )
+          )
+      );
+
+      const reactDatepickerSource = /node_modules[\\/]+react-datepicker[\\/]+src[\\/]+date_utils\.ts$/;
+
+      if (sourceMapRule) {
+        const existingExclude = sourceMapRule.exclude;
+
+        if (Array.isArray(existingExclude)) {
+          sourceMapRule.exclude = [...existingExclude, reactDatepickerSource];
+        } else if (existingExclude) {
+          sourceMapRule.exclude = [existingExclude, reactDatepickerSource];
+        } else {
+          sourceMapRule.exclude = [reactDatepickerSource];
+        }
+      }
+
+      webpackConfig.ignoreWarnings = [
+        ...(webpackConfig.ignoreWarnings || []),
+        /Critical dependency: the request of a dependency is an expression/
+      ];
+
+      return webpackConfig;
+    }
+  }
+};

--- a/react_web_app/package.json
+++ b/react_web_app/package.json
@@ -30,9 +30,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -54,6 +54,7 @@
     ]
   },
   "devDependencies": {
+    "@craco/craco": "^7.1.0",
     "@types/react-datepicker": "^7.0.0"
   }
 }

--- a/react_web_app/src/components/modals/member/AddMemberModal.tsx
+++ b/react_web_app/src/components/modals/member/AddMemberModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Timestamp } from 'firebase/firestore';
 import { Gradients } from '../../../constants/gradients';
 import { X, UserPlus, Search } from 'lucide-react';
@@ -226,9 +227,9 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
 
   if (!visible) return null;
 
-  return (
+  return createPortal(
     <div className="modal-overlay" onClick={handleClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-content add-member-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2 className="modal-title">
             <UserPlus size={20} />
@@ -514,7 +515,7 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             z-index: 1000;
           }
 
-          .modal-content {
+          .add-member-modal {
             background: white;
             border-radius: 12px;
             width: 90%;
@@ -525,7 +526,7 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             flex-direction: column;
           }
 
-          .modal-header {
+          .add-member-modal .modal-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -534,7 +535,7 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             color: white;
           }
 
-          .modal-title {
+          .add-member-modal .modal-title {
             margin: 0;
             font-size: 18px;
             font-weight: 600;
@@ -543,7 +544,7 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             gap: 8px;
           }
 
-          .close-button {
+          .add-member-modal .close-button {
             background: none;
             border: none;
             color: white;
@@ -553,11 +554,11 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             transition: background-color 0.2s;
           }
 
-          .close-button:hover {
+          .add-member-modal .close-button:hover {
             background-color: rgba(255, 255, 255, 0.1);
           }
 
-          .modal-body {
+          .add-member-modal .modal-body {
             flex: 1;
             overflow-y: auto;
             padding: 24px;
@@ -664,7 +665,7 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             overflow: hidden;
           }
 
-          .table-header {
+          .add-member-modal .table-header {
             display: grid;
             grid-template-columns: 1fr 1fr 2fr 1.5fr 100px;
             gap: 16px;
@@ -676,7 +677,7 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             font-size: 14px;
           }
 
-          .table-row {
+          .add-member-modal .table-row {
             display: grid;
             grid-template-columns: 1fr 1fr 2fr 1.5fr 100px;
             gap: 16px;
@@ -685,15 +686,15 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             transition: background-color 0.2s;
           }
 
-          .table-row:hover {
+          .add-member-modal .table-row:hover {
             background-color: #f9fafb;
           }
 
-          .table-row:last-child {
+          .add-member-modal .table-row:last-child {
             border-bottom: none;
           }
 
-          .table-cell {
+          .add-member-modal .table-cell {
             display: flex;
             align-items: center;
             font-size: 14px;
@@ -759,7 +760,7 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             gap: 12px;
           }
 
-          .btn {
+          .add-member-modal .btn {
             padding: 8px 16px;
             border-radius: 6px;
             border: 1px solid;
@@ -772,40 +773,40 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
             font-size: 14px;
           }
 
-          .btn:disabled {
+          .add-member-modal .btn:disabled {
             opacity: 0.6;
             cursor: not-allowed;
           }
 
-          .btn-sm {
+          .add-member-modal .btn-sm {
             padding: 6px 12px;
             font-size: 12px;
           }
 
-          .btn-primary {
+          .add-member-modal .btn-primary {
             background: ${Gradients.primary};
             border-color: #667eea;
             color: white;
           }
 
-          .btn-primary:hover:not(:disabled) {
+          .add-member-modal .btn-primary:hover:not(:disabled) {
             background: ${Gradients.primaryHover};
             transform: translateY(-1px);
             box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
           }
 
-          .btn-secondary {
+          .add-member-modal .btn-secondary {
             background-color: #f8fafc;
             border-color: #e2e8f0;
             color: #64748b;
           }
 
-          .btn-secondary:hover {
+          .add-member-modal .btn-secondary:hover {
             background-color: #f1f5f9;
             border-color: #cbd5e1;
           }
 
-          .modal-footer {
+          .add-member-modal .modal-footer {
             display: flex;
             justify-content: flex-end;
             gap: 12px;
@@ -815,9 +816,9 @@ const AddMemberModal = ({ visible, onClose, onSuccess, onError, createToast }: A
           }
         `}</style>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 
 export default AddMemberModal;
-

--- a/react_web_app/src/components/modals/member/ApplyRequestModal.tsx
+++ b/react_web_app/src/components/modals/member/ApplyRequestModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { Gradients } from '../../../constants/gradients';
 import { X, Users, Check, XCircle } from 'lucide-react';
 import { MemberService } from '../../../services/memberService';
@@ -92,9 +93,9 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
 
   if (!visible) return null;
 
-  return (
+  return createPortal(
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-content apply-request-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2 className="modal-title">
             <Users size={20} />
@@ -174,7 +175,7 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             z-index: 1000;
           }
 
-          .modal-content {
+          .apply-request-modal {
             background: white;
             border-radius: 12px;
             width: 90%;
@@ -185,7 +186,7 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             flex-direction: column;
           }
 
-          .modal-header {
+          .apply-request-modal .modal-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -194,7 +195,7 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             color: white;
           }
 
-          .modal-title {
+          .apply-request-modal .modal-title {
             margin: 0;
             font-size: 18px;
             font-weight: 600;
@@ -203,7 +204,7 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             gap: 8px;
           }
 
-          .close-button {
+          .apply-request-modal .close-button {
             background: none;
             border: none;
             color: white;
@@ -213,11 +214,11 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             transition: background-color 0.2s;
           }
 
-          .close-button:hover {
+          .apply-request-modal .close-button:hover {
             background-color: rgba(255, 255, 255, 0.1);
           }
 
-          .modal-body {
+          .apply-request-modal .modal-body {
             flex: 1;
             overflow-y: auto;
             padding: 24px;
@@ -225,7 +226,7 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             box-sizing: border-box;
           }
 
-          .loading-container {
+          .apply-request-modal .loading-container {
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -233,7 +234,7 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             padding: 40px 20px;
           }
 
-          .loading-spinner {
+          .apply-request-modal .loading-spinner {
             width: 32px;
             height: 32px;
             border: 3px solid #f3f4f6;
@@ -248,7 +249,7 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             100% { transform: rotate(360deg); }
           }
 
-          .empty-state {
+          .apply-request-modal .empty-state {
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -257,25 +258,25 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             text-align: center;
           }
 
-          .empty-icon {
+          .apply-request-modal .empty-icon {
             color: #9ca3af;
             margin-bottom: 16px;
           }
 
-          .empty-state p {
+          .apply-request-modal .empty-state p {
             margin: 0;
             color: #6b7280;
             font-size: 14px;
           }
 
-          .applicants-table {
+          .apply-request-modal .applicants-table {
             background: white;
             border-radius: 8px;
             border: 1px solid #e2e8f0;
             overflow: hidden;
           }
 
-          .table-header {
+          .apply-request-modal .table-header {
             display: grid !important;
             grid-template-columns: 2fr 3fr 2fr 100px !important;
             gap: 16px;
@@ -288,7 +289,7 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             width: 100%;
           }
 
-          .table-row {
+          .apply-request-modal .table-row {
             display: grid !important;
             grid-template-columns: 2fr 3fr 2fr 100px !important;
             gap: 16px;
@@ -298,15 +299,15 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             width: 100%;
           }
 
-          .table-row:hover {
+          .apply-request-modal .table-row:hover {
             background-color: #f9fafb;
           }
 
-          .table-row:last-child {
+          .apply-request-modal .table-row:last-child {
             border-bottom: none;
           }
 
-          .table-cell {
+          .apply-request-modal .table-cell {
             display: flex;
             align-items: center;
             font-size: 14px;
@@ -317,13 +318,13 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             min-width: 0;
           }
 
-          .actions-cell {
+          .apply-request-modal .actions-cell {
             display: flex;
             gap: 8px;
             justify-content: center;
           }
 
-          .btn {
+          .apply-request-modal .btn {
             padding: 8px 16px;
             border-radius: 6px;
             border: 1px solid;
@@ -336,50 +337,50 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
             font-size: 14px;
           }
 
-          .btn:disabled {
+          .apply-request-modal .btn:disabled {
             opacity: 0.6;
             cursor: not-allowed;
           }
 
-          .btn-sm {
+          .apply-request-modal .btn-sm {
             padding: 6px 10px;
             font-size: 12px;
           }
 
-          .btn-success {
+          .apply-request-modal .btn-success {
             background-color: #10b981;
             border-color: #10b981;
             color: white;
           }
 
-          .btn-success:hover:not(:disabled) {
+          .apply-request-modal .btn-success:hover:not(:disabled) {
             background-color: #059669;
             border-color: #059669;
           }
 
-          .btn-danger {
+          .apply-request-modal .btn-danger {
             background-color: #dc2626;
             border-color: #dc2626;
             color: white;
           }
 
-          .btn-danger:hover:not(:disabled) {
+          .apply-request-modal .btn-danger:hover:not(:disabled) {
             background-color: #b91c1c;
             border-color: #b91c1c;
           }
 
-          .btn-secondary {
+          .apply-request-modal .btn-secondary {
             background-color: #f8fafc;
             border-color: #e2e8f0;
             color: #64748b;
           }
 
-          .btn-secondary:hover {
+          .apply-request-modal .btn-secondary:hover {
             background-color: #f1f5f9;
             border-color: #cbd5e1;
           }
 
-          .modal-footer {
+          .apply-request-modal .modal-footer {
             display: flex;
             justify-content: flex-end;
             gap: 12px;
@@ -389,9 +390,9 @@ const ApplyRequestModal = ({ visible, onClose, onSuccess, onError }: ApplyReques
           }
         `}</style>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 
 export default ApplyRequestModal;
-

--- a/react_web_app/src/components/modals/member/MemberManagementModal.tsx
+++ b/react_web_app/src/components/modals/member/MemberManagementModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { User, Mail, Phone, Calendar, Users, Clock, CreditCard, Plus, Trash2, Square, DollarSign, CheckCircle, Edit, History } from 'lucide-react';
 import { MemberManagementModalProps, MembershipPlan, UserMembership, AddMembershipData } from '../../../types/membership';
 import { MemberLockerHistory } from '../../../types/member';
@@ -645,7 +646,7 @@ const MemberManagementModal = ({
 
   if (!visible || !member) return null;
 
-  return (
+  return createPortal(
     <div className="modal-overlay" onClick={handleClose}>
       <div className="modal-content member-management-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
@@ -1889,7 +1890,7 @@ const MemberManagementModal = ({
           overflow: hidden;
         }
 
-        .table-header {
+        .member-management-modal .table-header {
           display: grid !important;
           grid-template-columns: 2fr 2fr 1fr 1fr 2fr 1fr 90px 80px 80px 80px !important;
           gap: 16px;
@@ -1902,7 +1903,7 @@ const MemberManagementModal = ({
           width: 100%;
         }
 
-        .table-row {
+        .member-management-modal .table-row {
           display: grid !important;
           grid-template-columns: 2fr 2fr 1fr 1fr 2fr 1fr 90px 80px 80px 80px !important;
           gap: 16px;
@@ -1912,20 +1913,20 @@ const MemberManagementModal = ({
           width: 100%;
         }
 
-        .table-row:hover {
+        .member-management-modal .table-row:hover {
           background-color: #f9fafb;
         }
 
-        .table-row.refunded {
+        .member-management-modal .table-row.refunded {
           background-color: #fff7ed;
           opacity: 0.8;
         }
 
-        .table-row.refunded:hover {
+        .member-management-modal .table-row.refunded:hover {
           background-color: #ffedd5;
         }
 
-        .table-cell {
+        .member-management-modal .table-cell {
           display: flex;
           align-items: center;
           font-size: 14px;
@@ -1936,43 +1937,43 @@ const MemberManagementModal = ({
           min-width: 0;
         }
 
-        .table-cell:nth-child(1) { /* 시작일 */
+        .member-management-modal .table-cell:nth-child(1) { /* 시작일 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(2) { /* 종료일 */
+        .member-management-modal .table-cell:nth-child(2) { /* 종료일 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(3) { /* 타입 */
+        .member-management-modal .table-cell:nth-child(3) { /* 타입 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(4) { /* 가격 */
+        .member-management-modal .table-cell:nth-child(4) { /* 가격 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(5) { /* 플랜 */
+        .member-management-modal .table-cell:nth-child(5) { /* 플랜 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(6) { /* 담당자 */
+        .member-management-modal .table-cell:nth-child(6) { /* 담당자 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(7) { /* 조정 이력 */
+        .member-management-modal .table-cell:nth-child(7) { /* 조정 이력 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(8) { /* 수정 */
+        .member-management-modal .table-cell:nth-child(8) { /* 수정 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(9) { /* 환불 */
+        .member-management-modal .table-cell:nth-child(9) { /* 환불 */
           justify-content: center;
         }
 
-        .table-cell:nth-child(10) { /* 삭제 */
+        .member-management-modal .table-cell:nth-child(10) { /* 삭제 */
           justify-content: center;
         }
 
@@ -2256,13 +2257,13 @@ const MemberManagementModal = ({
             grid-template-columns: 1fr;
           }
 
-          .table-header,
-          .table-row {
+          .member-management-modal .table-header,
+          .member-management-modal .table-row {
             grid-template-columns: 1fr;
             gap: 8px;
           }
 
-          .table-cell {
+          .member-management-modal .table-cell {
             padding: 8px 0;
           }
         }
@@ -2277,7 +2278,8 @@ const MemberManagementModal = ({
           margin-bottom: 0;
         }
       `}</style>
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/react_web_app/src/pages/BoxSettings.tsx
+++ b/react_web_app/src/pages/BoxSettings.tsx
@@ -252,7 +252,7 @@ const BoxSettings = () => {
   }, [loadBoxInfo, createToast]);
 
   return (
-    <div className="dashboard">
+    <div className="dashboard box-settings-page">
       {/* 컨트롤 카드 */}
       <div className="content-card">
         <div className="card-header">
@@ -678,11 +678,11 @@ const BoxSettings = () => {
           margin-top: 22px;
         }
 
-        .coaches-table {
+        .box-settings-page .coaches-table {
           width: 100%;
         }
 
-        .table-header {
+        .box-settings-page .table-header {
           display: grid;
           grid-template-columns: 1fr 1fr 1fr 80px;
           gap: 16px;
@@ -694,7 +694,7 @@ const BoxSettings = () => {
           font-size: 14px;
         }
 
-        .table-row {
+        .box-settings-page .table-row {
           display: grid;
           grid-template-columns: 1fr 1fr 1fr 80px;
           gap: 16px;
@@ -703,11 +703,11 @@ const BoxSettings = () => {
           transition: all 0.2s;
         }
 
-        .table-row:hover {
+        .box-settings-page .table-row:hover {
           background-color: #f9fafb;
         }
 
-        .table-cell {
+        .box-settings-page .table-cell {
           display: flex;
           align-items: center;
           font-size: 14px;
@@ -849,13 +849,13 @@ const BoxSettings = () => {
             margin-top: 12px;
           }
 
-          .table-header,
-          .table-row {
+          .box-settings-page .table-header,
+          .box-settings-page .table-row {
             grid-template-columns: 1fr;
             gap: 8px;
           }
 
-          .table-cell {
+          .box-settings-page .table-cell {
             padding: 8px 0;
           }
         }

--- a/react_web_app/src/pages/Dashboard.tsx
+++ b/react_web_app/src/pages/Dashboard.tsx
@@ -166,7 +166,7 @@ const Dashboard = () => {
   );
 
   return (
-    <div className="dashboard">
+    <div className="dashboard dashboard-page">
       {/* 통계 카드들 */}
       <div className="stats-grid">
         {statsData.map((stat, index) => (
@@ -329,12 +329,12 @@ const Dashboard = () => {
           overflow-x: auto;
         }
 
-        .classes-table {
+        .dashboard-page .classes-table {
           width: 100%;
           min-width: 600px;
         }
 
-        .table-header {
+        .dashboard-page .table-header {
           display: grid;
           grid-template-columns: 120px 1fr 120px 150px 120px;
           gap: 16px;
@@ -346,7 +346,7 @@ const Dashboard = () => {
           font-size: 14px;
         }
 
-        .table-row {
+        .dashboard-page .table-row {
           display: grid;
           grid-template-columns: 120px 1fr 120px 150px 120px;
           gap: 16px;
@@ -355,11 +355,11 @@ const Dashboard = () => {
           transition: all 0.2s;
         }
 
-        .table-row:hover {
+        .dashboard-page .table-row:hover {
           background-color: #f9fafb;
         }
 
-        .table-cell {
+        .dashboard-page .table-cell {
           display: flex;
           align-items: center;
           font-size: 14px;

--- a/react_web_app/src/pages/MemberManagement.tsx
+++ b/react_web_app/src/pages/MemberManagement.tsx
@@ -317,7 +317,7 @@ const MemberManagement = () => {
   };
 
   return (
-    <div className="dashboard">
+    <div className="dashboard member-management-page">
       {/* 액션 버튼들 */}
       <div className="actions-bar">
         <button className="btn btn-info btn-with-badge" onClick={() => setApplyRequestModalVisible(true)}>
@@ -1017,12 +1017,12 @@ const MemberManagement = () => {
           box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
         }
 
-        .members-table {
+        .member-management-page .members-table {
           width: 100%;
           min-width: 700px;
         }
 
-        .table-header {
+        .member-management-page .table-header {
           display: grid;
           grid-template-columns: 1fr 1fr 1fr 1.2fr 1.5fr 1fr 120px;
           gap: 16px;
@@ -1034,7 +1034,7 @@ const MemberManagement = () => {
           font-size: 14px;
         }
 
-        .table-row {
+        .member-management-page .table-row {
           display: grid;
           grid-template-columns: 1fr 1fr 1fr 1.2fr 1.5fr 1fr 120px;
           gap: 16px;
@@ -1043,11 +1043,11 @@ const MemberManagement = () => {
           transition: all 0.2s;
         }
 
-        .table-row:hover {
+        .member-management-page .table-row:hover {
           background-color: #f9fafb;
         }
 
-        .table-cell {
+        .member-management-page .table-cell {
           display: flex;
           align-items: center;
           font-size: 14px;
@@ -1055,7 +1055,7 @@ const MemberManagement = () => {
         }
 
         /* 헤더/바디 모두에서 관리 컬럼을 중앙 정렬 */
-        .table-header .table-cell:last-child {
+        .member-management-page .table-header .table-cell:last-child {
           justify-content: center;
         }
 

--- a/react_web_app/src/services/lockerService.ts
+++ b/react_web_app/src/services/lockerService.ts
@@ -1,10 +1,28 @@
 import { getDoc, doc, runTransaction } from 'firebase/firestore';
 import { db } from '../config/firebase';
-import { Locker, LOCKER_STATE, LockerState } from '../types/locker';
+import { Locker, LOCKER_STATE, LockerState, getLockerState } from '../types/locker';
 import { toLocker } from '../utils/lockerUtils';
 import { formatDateToString } from '../utils/dateUtils';
 
 export class LockerService {
+  private static hasActiveAssignedUser(lockerEntryData: unknown, lockerNumber: number): boolean {
+    if (Array.isArray(lockerEntryData)) {
+      if (lockerEntryData.length === 0) {
+        return false;
+      }
+
+      const latestLocker = toLocker(lockerEntryData[lockerEntryData.length - 1], lockerNumber);
+      return latestLocker.realName.trim().length > 0 && getLockerState(latestLocker.state, latestLocker) === LOCKER_STATE.USED;
+    }
+
+    if (lockerEntryData && typeof lockerEntryData === 'object') {
+      const latestLocker = toLocker(lockerEntryData, lockerNumber);
+      return latestLocker.realName.trim().length > 0 && getLockerState(latestLocker.state, latestLocker) === LOCKER_STATE.USED;
+    }
+
+    return false;
+  }
+
   static async getLockers(box: string): Promise<Locker[]> {
     // lockerdoc 은 "문서"이므로 getDoc + doc 사용
     const ref = doc(db, `box/${box}/lockers/lockerdoc`);
@@ -74,28 +92,28 @@ export class LockerService {
         
         // 키가 존재하는지 확인
         if (Object.prototype.hasOwnProperty.call(existing, key)) {
-          const existingValue = existing[key];
+          const lockerEntry = existing[key];
           let isDeleted = false;
           
           // 배열인 경우와 객체인 경우 모두 확인
-          if (Array.isArray(existingValue)) {
+          if (Array.isArray(lockerEntry)) {
             // 배열의 마지막 항목이 deleted 상태인지 확인
-            const lastItem = existingValue[existingValue.length - 1];
+            const lastItem = lockerEntry[lockerEntry.length - 1];
             isDeleted = lastItem?.state === LOCKER_STATE.DELETED;
             
             if (isDeleted) {
               // deleted 상태면 배열에 새 항목 추가
-              toSet[key] = [...existingValue, defaultEntry];
+              toSet[key] = [...lockerEntry, defaultEntry];
               added.push(n);
             } else {
               skipped.push(n);
             }
-          } else if (existingValue && typeof existingValue === 'object') {
-            isDeleted = (existingValue as any)?.state === LOCKER_STATE.DELETED;
+          } else if (lockerEntry && typeof lockerEntry === 'object') {
+            isDeleted = (lockerEntry as any)?.state === LOCKER_STATE.DELETED;
             
             if (isDeleted) {
               // 객체를 배열로 변환하고 새 항목 추가
-              toSet[key] = [existingValue, defaultEntry];
+              toSet[key] = [lockerEntry, defaultEntry];
               added.push(n);
             } else {
               skipped.push(n);
@@ -132,7 +150,7 @@ export class LockerService {
         throw new Error('해당 락커 번호를 찾을 수 없습니다.');
       }
 
-      const existingValue = data[key];
+      const lockerEntry = data[key];
       const deletedEntry: Locker = {
         number: lockerNumber,
         state: LOCKER_STATE.DELETED,
@@ -149,28 +167,28 @@ export class LockerService {
 
       let newValue: any;
 
-      if (Array.isArray(existingValue)) {
-        const lastItem = existingValue[existingValue.length - 1];
+      if (Array.isArray(lockerEntry)) {
+        const lastItem = lockerEntry[lockerEntry.length - 1];
         const hasName = (lastItem?.realName || '').trim().length > 0;
 
         if (hasName) {
           // 이름이 있으면 배열에 새로운 deleted 항목 추가
-          newValue = [...existingValue, deletedEntry];
+          newValue = [...lockerEntry, deletedEntry];
         } else {
           // 이름이 없으면 마지막 항목의 상태만 deleted로 변경
-          const updated = [...existingValue];
+          const updated = [...lockerEntry];
           updated[updated.length - 1] = { ...lastItem, state: LOCKER_STATE.DELETED };
           newValue = updated;
         }
-      } else if (existingValue && typeof existingValue === 'object') {
-        const hasName = ((existingValue as any)?.realName || '').trim().length > 0;
+      } else if (lockerEntry && typeof lockerEntry === 'object') {
+        const hasName = ((lockerEntry as any)?.realName || '').trim().length > 0;
 
         if (hasName) {
           // 이름이 있으면 배열로 변환하고 deleted 항목 추가
-          newValue = [existingValue, deletedEntry];
+          newValue = [lockerEntry, deletedEntry];
         } else {
           // 이름이 없으면 상태만 deleted로 변경
-          newValue = { ...existingValue, state: LOCKER_STATE.DELETED };
+          newValue = { ...lockerEntry, state: LOCKER_STATE.DELETED };
         }
       } else {
         throw new Error('잘못된 락커 데이터 형식입니다.');
@@ -196,7 +214,7 @@ export class LockerService {
         throw new Error('해당 락커 번호를 찾을 수 없습니다.');
       }
 
-      const existingValue = data[key];
+      const lockerEntry = data[key];
       // 해지 사유 앞에 "[해지] " 접두사 추가
       const releaseNote = note.trim() ? `[해지] ${note}` : note;
       
@@ -216,12 +234,12 @@ export class LockerService {
 
       let newValue: any;
 
-      if (Array.isArray(existingValue)) {
+      if (Array.isArray(lockerEntry)) {
         // 배열에 새로운 unused 항목 추가
-        newValue = [...existingValue, unusedEntry];
-      } else if (existingValue && typeof existingValue === 'object') {
+        newValue = [...lockerEntry, unusedEntry];
+      } else if (lockerEntry && typeof lockerEntry === 'object') {
         // 객체를 배열로 변환하고 unused 항목 추가
-        newValue = [existingValue, unusedEntry];
+        newValue = [lockerEntry, unusedEntry];
       } else {
         throw new Error('잘못된 락커 데이터 형식입니다.');
       }
@@ -256,16 +274,9 @@ export class LockerService {
         throw new Error('해당 락커 번호를 찾을 수 없습니다.');
       }
 
-      const existingValue = data[key];
+      const lockerEntry = data[key];
       
-      // 현재 사용자가 할당되어 있는지 확인
-      let hasUser = false;
-      if (Array.isArray(existingValue)) {
-        const lastItem = existingValue[existingValue.length - 1];
-        hasUser = (lastItem?.realName || '').trim().length > 0;
-      } else if (existingValue && typeof existingValue === 'object') {
-        hasUser = ((existingValue as any)?.realName || '').trim().length > 0;
-      }
+      const hasUser = this.hasActiveAssignedUser(lockerEntry, lockerNumber);
 
       if (hasUser) {
         throw new Error('회원을 먼저 해지하시기 바랍니다.');
@@ -288,20 +299,20 @@ export class LockerService {
       let newValue: any;
       const hasNote = note.trim().length > 0;
 
-      if (Array.isArray(existingValue)) {
+      if (Array.isArray(lockerEntry)) {
         if (hasNote) {
           // note가 있으면 배열에 새 항목 추가
-          newValue = [...existingValue, updatedEntry];
+          newValue = [...lockerEntry, updatedEntry];
         } else {
           // note가 없으면 마지막 항목 업데이트
-          const updated = [...existingValue];
+          const updated = [...lockerEntry];
           updated[updated.length - 1] = updatedEntry;
           newValue = updated;
         }
-      } else if (existingValue && typeof existingValue === 'object') {
+      } else if (lockerEntry && typeof lockerEntry === 'object') {
         if (hasNote) {
           // note가 있으면 객체를 배열로 변환하고 새 항목 추가
-          newValue = [existingValue, updatedEntry];
+          newValue = [lockerEntry, updatedEntry];
         } else {
           // note가 없으면 객체를 업데이트
           newValue = updatedEntry;
@@ -329,18 +340,18 @@ export class LockerService {
       return [];
     }
 
-    const value = data[key];
+    const lockerEntryData = data[key];
     const history: Locker[] = [];
 
 
-    if (Array.isArray(value)) {
+    if (Array.isArray(lockerEntryData)) {
       // 배열인 경우 모든 항목을 히스토리로 반환
-      for (const item of value) {
+      for (const item of lockerEntryData) {
         history.push(toLocker(item, lockerNumber));
       }
-    } else if (value && typeof value === 'object') {
+    } else if (lockerEntryData && typeof lockerEntryData === 'object') {
       // 객체인 경우 단일 항목
-      history.push(toLocker(value, lockerNumber));
+      history.push(toLocker(lockerEntryData, lockerNumber));
     }
 
     return history;
@@ -373,16 +384,9 @@ export class LockerService {
         throw new Error('해당 락커 번호를 찾을 수 없습니다.');
       }
 
-      const existingValue = data[lockerKey];
+      const lockerEntry = data[lockerKey];
       
-      // 현재 사용자가 할당되어 있는지 확인
-      let hasUser = false;
-      if (Array.isArray(existingValue)) {
-        const lastItem = existingValue[existingValue.length - 1];
-        hasUser = (lastItem?.realName || '').trim().length > 0;
-      } else if (existingValue && typeof existingValue === 'object') {
-        hasUser = ((existingValue as any)?.realName || '').trim().length > 0;
-      }
+      const hasUser = this.hasActiveAssignedUser(lockerEntry, lockerNumber);
 
       if (hasUser) {
         throw new Error('이미 회원이 배정되어 있습니다. 먼저 해지해주세요.');
@@ -406,29 +410,29 @@ export class LockerService {
 
       let newValue: any;
 
-      if (Array.isArray(existingValue)) {
-        const lastItem = existingValue[existingValue.length - 1];
+      if (Array.isArray(lockerEntry)) {
+        const lastItem = lockerEntry[lockerEntry.length - 1];
         const isUnusedWithNoNote = lastItem?.state === LOCKER_STATE.UNUSED && (!lastItem?.note || lastItem.note.trim() === '');
         
         if (isUnusedWithNoNote) {
           // 사용 가능 상태이고 note가 없으면 마지막 항목 덮어쓰기
-          const updated = [...existingValue];
+          const updated = [...lockerEntry];
           updated[updated.length - 1] = assignedEntry;
           newValue = updated;
         } else {
           // 그렇지 않으면 새 항목 추가
-          newValue = [...existingValue, assignedEntry];
+          newValue = [...lockerEntry, assignedEntry];
         }
-      } else if (existingValue && typeof existingValue === 'object') {
-        const isUnusedWithNoNote = (existingValue as any)?.state === LOCKER_STATE.UNUSED && 
-                                     (!(existingValue as any)?.note || (existingValue as any).note.trim() === '');
+      } else if (lockerEntry && typeof lockerEntry === 'object') {
+        const isUnusedWithNoNote = (lockerEntry as any)?.state === LOCKER_STATE.UNUSED && 
+                                     (!(lockerEntry as any)?.note || (lockerEntry as any).note.trim() === '');
         
         if (isUnusedWithNoNote) {
           // 사용 가능 상태이고 note가 없으면 객체 덮어쓰기
           newValue = assignedEntry;
         } else {
           // 그렇지 않으면 배열로 변환하고 새 항목 추가
-          newValue = [existingValue, assignedEntry];
+          newValue = [lockerEntry, assignedEntry];
         }
       } else {
         throw new Error('잘못된 락커 데이터 형식입니다.');

--- a/react_web_app/src/services/lockerService.ts
+++ b/react_web_app/src/services/lockerService.ts
@@ -4,8 +4,21 @@ import { Locker, LOCKER_STATE, LockerState, getLockerState } from '../types/lock
 import { toLocker } from '../utils/lockerUtils';
 import { formatDateToString } from '../utils/dateUtils';
 
+type LockerDocumentEntry = Locker | Locker[];
+type LockerDocumentData = Record<string, LockerDocumentEntry>;
+
 export class LockerService {
-  private static hasActiveAssignedUser(lockerEntryData: unknown, lockerNumber: number): boolean {
+  /**
+   * 특정 락커 엔트리에 현재 활성 배정 회원이 있는지 확인합니다.
+   *
+   * 최신 엔트리를 기준으로 회원 이름이 존재하고, 날짜 기준 실제 상태가
+   * `used`인 경우에만 배정 중으로 판단합니다.
+   *
+   * @param lockerEntryData 락커 문서에 저장된 단일 엔트리 또는 히스토리 배열
+   * @param lockerNumber 확인할 락커 번호
+   * @returns 현재 배정된 회원이 있으면 `true`
+   */
+  private static hasActiveAssignedUser(lockerEntryData: LockerDocumentEntry, lockerNumber: number): boolean {
     if (Array.isArray(lockerEntryData)) {
       if (lockerEntryData.length === 0) {
         return false;
@@ -23,13 +36,21 @@ export class LockerService {
     return false;
   }
 
+  /**
+   * 박스의 전체 락커 목록을 조회합니다.
+   *
+   * 각 락커 번호별로 최신 엔트리만 꺼내 `Locker` 형태로 반환합니다.
+   *
+   * @param box 박스 이름
+   * @returns 최신 상태 기준의 락커 목록
+   */
   static async getLockers(box: string): Promise<Locker[]> {
     // lockerdoc 은 "문서"이므로 getDoc + doc 사용
     const ref = doc(db, `box/${box}/lockers/lockerdoc`);
     const snap = await getDoc(ref);
     if (!snap.exists()) return [];
 
-    const data = snap.data() as Record<string, unknown>;
+    const data = snap.data() as LockerDocumentData;
     const out: Locker[] = [];
 
     for (const [key, value] of Object.entries(data)) {
@@ -56,6 +77,16 @@ export class LockerService {
     return out;
   }
 
+  /**
+   * 지정한 번호 범위의 락커를 추가합니다.
+   *
+   * 이미 존재하는 락커는 건너뛰고, 삭제 상태였던 락커는 다시 활성화합니다.
+   *
+   * @param box 박스 이름
+   * @param start 시작 번호
+   * @param end 종료 번호
+   * @returns 추가된 번호와 건너뛴 번호 목록
+   */
   static async addLockers(
     box: string,
     start: number,
@@ -67,9 +98,9 @@ export class LockerService {
 
     return runTransaction(db, async (tx) => {
       const snap = await tx.get(ref);
-      const existing = snap.exists() ? (snap.data() as Record<string, unknown>) : {};
+      const existing: LockerDocumentData = snap.exists() ? (snap.data() as LockerDocumentData) : {};
 
-      const toSet: Record<string, unknown> = {};
+      const toSet: LockerDocumentData = {};
       const added: number[] = [];
       const skipped: number[] = [];
 
@@ -134,6 +165,15 @@ export class LockerService {
     });
   }
 
+  /**
+   * 락커를 삭제 상태로 변경합니다.
+   *
+   * 회원이 배정된 이력이 있으면 삭제 히스토리를 추가하고,
+   * 그렇지 않으면 최신 엔트리의 상태만 삭제로 바꿉니다.
+   *
+   * @param box 박스 이름
+   * @param lockerNumber 삭제할 락커 번호
+   */
   static async deleteLocker(box: string, lockerNumber: number): Promise<void> {
     const ref = doc(db, 'box', box, 'lockers', 'lockerdoc');
 
@@ -143,7 +183,7 @@ export class LockerService {
         throw new Error('락커 문서를 찾을 수 없습니다.');
       }
 
-      const data = snap.data() as Record<string, unknown>;
+      const data = snap.data() as LockerDocumentData;
       const key = String(lockerNumber);
 
       if (!Object.prototype.hasOwnProperty.call(data, key)) {
@@ -198,6 +238,14 @@ export class LockerService {
     });
   }
 
+  /**
+   * 사용 중인 락커를 해지하고 사용 가능 상태 엔트리를 추가합니다.
+   *
+   * @param box 박스 이름
+   * @param lockerNumber 해지할 락커 번호
+   * @param note 해지 사유 메모
+   * @param assignee 처리자 이름
+   */
   static async releaseLocker(box: string, lockerNumber: number, note: string = '', assignee: string = ''): Promise<void> {
     const ref = doc(db, 'box', box, 'lockers', 'lockerdoc');
 
@@ -207,7 +255,7 @@ export class LockerService {
         throw new Error('락커 문서를 찾을 수 없습니다.');
       }
 
-      const data = snap.data() as Record<string, unknown>;
+      const data = snap.data() as LockerDocumentData;
       const key = String(lockerNumber);
 
       if (!Object.prototype.hasOwnProperty.call(data, key)) {
@@ -248,6 +296,17 @@ export class LockerService {
     });
   }
 
+  /**
+   * 비어 있는 락커의 상태를 변경합니다.
+   *
+   * 회원이 배정된 락커는 변경할 수 없으며, `unused` 또는 `na` 상태만 지원합니다.
+   *
+   * @param box 박스 이름
+   * @param lockerNumber 변경할 락커 번호
+   * @param state 변경할 상태
+   * @param note 변경 사유 메모
+   * @param assignee 처리자 이름
+   */
   static async updateLocker(
     box: string,
     lockerNumber: number,
@@ -267,7 +326,7 @@ export class LockerService {
         throw new Error('락커 문서를 찾을 수 없습니다.');
       }
 
-      const data = snap.data() as Record<string, unknown>;
+      const data = snap.data() as LockerDocumentData;
       const key = String(lockerNumber);
 
       if (!Object.prototype.hasOwnProperty.call(data, key)) {
@@ -325,6 +384,13 @@ export class LockerService {
     });
   }
 
+  /**
+   * 특정 락커 번호의 전체 히스토리를 조회합니다.
+   *
+   * @param box 박스 이름
+   * @param lockerNumber 조회할 락커 번호
+   * @returns 오래된 순서대로 정리된 락커 히스토리 목록
+   */
   static async getLockerHistory(box: string, lockerNumber: number): Promise<Locker[]> {
     const ref = doc(db, 'box', box, 'lockers', 'lockerdoc');
     const snap = await getDoc(ref);
@@ -333,7 +399,7 @@ export class LockerService {
       return [];
     }
 
-    const data = snap.data() as Record<string, unknown>;
+    const data = snap.data() as LockerDocumentData;
     const key = String(lockerNumber);
 
     if (!Object.prototype.hasOwnProperty.call(data, key)) {
@@ -357,6 +423,23 @@ export class LockerService {
     return history;
   }
 
+  /**
+   * 회원을 락커에 배정합니다.
+   *
+   * 현재 활성 배정 회원이 없는 경우에만 배정 가능하며,
+   * 기존 최신 엔트리 상태에 따라 덮어쓰기 또는 히스토리 추가를 수행합니다.
+   *
+   * @param box 박스 이름
+   * @param lockerNumber 배정할 락커 번호
+   * @param userId 회원 식별자
+   * @param userName 회원 이름
+   * @param phoneNumber 회원 연락처
+   * @param startDate 사용 시작일
+   * @param endDate 사용 종료일
+   * @param key 락커 배정 고유 키
+   * @param price 결제 금액
+   * @param paymentType 결제 수단
+   */
   static async assignLocker(
     box: string,
     lockerNumber: number,
@@ -377,7 +460,7 @@ export class LockerService {
         throw new Error('락커 문서를 찾을 수 없습니다.');
       }
 
-      const data = snap.data() as Record<string, unknown>;
+      const data = snap.data() as LockerDocumentData;
       const lockerKey = String(lockerNumber);
 
       if (!Object.prototype.hasOwnProperty.call(data, lockerKey)) {
@@ -443,8 +526,14 @@ export class LockerService {
   }
 
   /**
-   * 전체 락커 연장
-   * 현재 사용 중인 모든 락커의 만료일을 연장합니다.
+   * 현재 사용 중인 모든 락커의 만료일을 일괄 연장합니다.
+   *
+   * 만료되지 않은 활성 락커만 대상으로 하며, 회원 히스토리 갱신에 필요한
+   * 최소 정보도 함께 반환합니다.
+   *
+   * @param box 박스 이름
+   * @param days 연장할 일수
+   * @returns 연장된 개수와 후속 처리용 락커 정보
    */
   static async extendAllLockers(
     box: string,
@@ -463,7 +552,7 @@ export class LockerService {
         return { extendedCount: 0, extendedLockers: [] };
       }
 
-      const data = snap.data() as Record<string, unknown>;
+      const data = snap.data() as LockerDocumentData;
       let extendedCount = 0;
       const updates: Record<string, any> = {};
       const extendedLockers: Array<{ id: string; key: string; endDate: string }> = [];


### PR DESCRIPTION
## 목적
- 회원 관리 화면에서 모달을 열 때 발생하던 CSS collision 문제를 수정합니다.
- 같은 패턴의 전역 스타일 충돌이 다시 생기지 않도록 주요 화면과 모달의 스타일 범위를 정리합니다.

## 주요 변경사항
- `MemberManagementModal`, `ApplyRequestModal`, `AddMemberModal`을 `createPortal(..., document.body)` 방식으로 렌더링하도록 변경했습니다.
- 회원 관리 페이지의 회원 목록 테이블 스타일을 페이지 루트 기준으로 제한해 모달 스타일이 뒤 표에 영향을 주지 않도록 정리했습니다.
- `ApplyRequestModal`, `AddMemberModal`의 `table`, `modal`, `btn` 관련 스타일을 각 모달 루트 클래스 아래로 한정했습니다.
- `Dashboard`, `BoxSettings`의 테이블 스타일을 각 페이지 루트 클래스 아래로 한정해 향후 CSS 충돌 가능성을 줄였습니다.

## 테스트
- `npm run build` (`react_web_app`)
