### PR TITLE
fix: BoxStatus 필드 통합 미완료 부분 수정

### DIFF
--- a/react_web_app/src/repositories/memberRepository.ts
+++ b/react_web_app/src/repositories/memberRepository.ts
@@ -202,7 +202,7 @@ export class MemberRepository {
       { [email]: deleteField() },
       { merge: true }
     );
-    batch.update(doc(db, `user/${email}`), { boxName });
+    batch.update(doc(db, `user/${email}`), { boxName, status: 'APPROVED' });
     batch.set(doc(db, `box/${boxName}/member`, email), memberData, { merge: true });
     await batch.commit();
   }
@@ -210,7 +210,7 @@ export class MemberRepository {
   /**
    * 가입 신청 거절 처리를 단일 writeBatch로 커밋합니다.
    *
-   * `applied/applieddoc`에서 신청자 제거 + `user/{email}.boxName`을 빈 문자열로 갱신.
+   * `applied/applieddoc`에서 신청자 제거 + `user/{email}.boxName`을 빈 문자열로 갱신하고 status를 REJECTED로 설정.
    *
    * @param email 신청자 이메일
    * @param boxName 신청이 등록되어 있던 박스 이름
@@ -222,7 +222,7 @@ export class MemberRepository {
       { [email]: deleteField() },
       { merge: true }
     );
-    batch.update(doc(db, `user/${email}`), { boxName: '' });
+    batch.update(doc(db, `user/${email}`), { boxName: '', status: 'REJECTED' });
     await batch.commit();
   }
 

--- a/react_web_app/src/services/memberService.ts
+++ b/react_web_app/src/services/memberService.ts
@@ -354,6 +354,7 @@ export class MemberService {
       }
 
       memberData.boxName = actualBoxName;
+      memberData.status = 'APPROVED';
       memberData.joinedAt = Timestamp.now();
 
       // applied 제거 + user.boxName 갱신 + member 생성을 단일 writeBatch로 원자 커밋.
@@ -365,16 +366,17 @@ export class MemberService {
   }
 
   /**
-   * 가입 신청을 거절합니다. boxName의 ? 접두사는 유지하고 status만 REJECTED로 변경합니다.
+   * 가입 신청을 거절합니다.
+   *
+   * applied 컬렉션에서 신청 제거, user 문서의 boxName을 빈 문자열로, status를 REJECTED로 설정합니다.
    *
    * @param email 신청자 이메일
    * @param boxName 박스 이름
    */
   static async rejectApplicant(email: string, boxName: string): Promise<void> {
     try {
-      // applied 제거 + user.boxName 비우기를 단일 writeBatch로 원자 커밋.
+      // applied 제거 + user.boxName 비우기 + status REJECTED 설정을 단일 writeBatch로 원자 커밋.
       await MemberRepository.commitRejectApplicantBatch(email, boxName);
-
     } catch (error) {
       console.error('Failed to reject applicant:', error);
       throw error;


### PR DESCRIPTION
## Summary

가입 신청 승인/거절 시 BoxStatus 필드가 제대로 반영되지 않던 문제를 해결했습니다.

## Changes

- **memberRepository.ts**
  - `commitApproveApplicantBatch`: user 문서 업데이트 시 `status: 'APPROVED'` 추가
  - `commitRejectApplicantBatch`: user 문서 업데이트 시 `status: 'REJECTED'` 추가

- **memberService.ts**
  - `approveApplicant`: memberData에 `status: 'APPROVED'` 설정
  - `rejectApplicant`: 주석 명확화 및 구현과 일치하도록 수정

## Context

최근 병합(9413906)에서 두 브랜치의 기능을 통합할 때 BoxStatus 필드 설정이 누락되었습니다:
- develop/v1.1: BoxStatus 타입 및 상태 관리 메서드 추가
- master: 가입 신청 배치 처리 메서드 추가

이제 둘이 제대로 협력하여 가입 신청 승인/거절 시 상태가 정확히 기록됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)