### PR TITLE
feat: Add Hybrid Repository layer for FastAPI server sync (all domains)

### DIFF
--- a/src/data/apiClient.ts
+++ b/src/data/apiClient.ts
@@ -45,6 +45,16 @@ async function patch<T>(path: string, body: unknown): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+async function put<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
+    method: 'PUT',
+    headers: { ...baseHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: PUT ${path}`);
+  return res.json() as Promise<T>;
+}
+
 async function del(path: string): Promise<void> {
   const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
     method: 'DELETE',
@@ -53,7 +63,7 @@ async function del(path: string): Promise<void> {
   if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}: DELETE ${path}`);
 }
 
-export const api = { get, post, patch, delete: del };
+export const api = { get, post, put, patch, delete: del };
 
 export async function serverRead<T>(fetcher: () => Promise<T>, label: string): Promise<T | null> {
   try {

--- a/src/data/apiClient.ts
+++ b/src/data/apiClient.ts
@@ -1,0 +1,64 @@
+import { SERVER_URL, SERVER_TIMEOUT_MS } from './apiConfig';
+
+async function fetchWithTimeout(url: string, options?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), SERVER_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { ...options, signal: controller.signal });
+    clearTimeout(id);
+    return res;
+  } catch (err) {
+    clearTimeout(id);
+    throw err;
+  }
+}
+
+async function get<T>(path: string): Promise<T> {
+  const res = await fetchWithTimeout(`${SERVER_URL}${path}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: GET ${path}`);
+  return res.json() as Promise<T>;
+}
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: POST ${path}`);
+  return res.json() as Promise<T>;
+}
+
+async function patch<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: PATCH ${path}`);
+  return res.json() as Promise<T>;
+}
+
+async function del(path: string): Promise<void> {
+  const res = await fetchWithTimeout(`${SERVER_URL}${path}`, { method: 'DELETE' });
+  if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}: DELETE ${path}`);
+}
+
+export const api = { get, post, patch, delete: del };
+
+export async function serverRead<T>(fetcher: () => Promise<T>, label: string): Promise<T | null> {
+  try {
+    const result = await fetcher();
+    console.log(`[SERVER] ${label} ✓`);
+    return result;
+  } catch (err) {
+    console.warn(`[SERVER] ${label} ✗ - fallback to Firebase`, err);
+    return null;
+  }
+}
+
+export function serverWrite(writer: () => Promise<unknown>, label: string): void {
+  writer()
+    .then(() => console.log(`[SERVER] ${label} ✓`))
+    .catch((err) => console.warn(`[SERVER] ${label} ✗`, err));
+}

--- a/src/data/apiClient.ts
+++ b/src/data/apiClient.ts
@@ -1,4 +1,5 @@
 import { SERVER_URL, SERVER_TIMEOUT_MS, SERVER_API_KEY } from './apiConfig';
+import { encryptUserEmail } from './userToken';
 
 async function fetchWithTimeout(url: string, options?: RequestInit): Promise<Response> {
   const controller = new AbortController();
@@ -13,13 +14,16 @@ async function fetchWithTimeout(url: string, options?: RequestInit): Promise<Res
   }
 }
 
-const baseHeaders = (): Record<string, string> => ({
-  'X-API-Key': SERVER_API_KEY,
-});
+const baseHeaders = async (): Promise<Record<string, string>> => {
+  const headers: Record<string, string> = { 'X-API-Key': SERVER_API_KEY };
+  const token = await encryptUserEmail();
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+};
 
 async function get<T>(path: string): Promise<T> {
   const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
-    headers: baseHeaders(),
+    headers: await baseHeaders(),
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}: GET ${path}`);
   return res.json() as Promise<T>;
@@ -28,7 +32,7 @@ async function get<T>(path: string): Promise<T> {
 async function post<T>(path: string, body: unknown): Promise<T> {
   const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
     method: 'POST',
-    headers: { ...baseHeaders(), 'Content-Type': 'application/json' },
+    headers: { ...await baseHeaders(), 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}: POST ${path}`);
@@ -38,7 +42,7 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 async function patch<T>(path: string, body: unknown): Promise<T> {
   const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
     method: 'PATCH',
-    headers: { ...baseHeaders(), 'Content-Type': 'application/json' },
+    headers: { ...await baseHeaders(), 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}: PATCH ${path}`);
@@ -48,7 +52,7 @@ async function patch<T>(path: string, body: unknown): Promise<T> {
 async function put<T>(path: string, body: unknown): Promise<T> {
   const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
     method: 'PUT',
-    headers: { ...baseHeaders(), 'Content-Type': 'application/json' },
+    headers: { ...await baseHeaders(), 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}: PUT ${path}`);
@@ -58,7 +62,7 @@ async function put<T>(path: string, body: unknown): Promise<T> {
 async function del(path: string): Promise<void> {
   const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
     method: 'DELETE',
-    headers: baseHeaders(),
+    headers: await baseHeaders(),
   });
   if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}: DELETE ${path}`);
 }

--- a/src/data/apiClient.ts
+++ b/src/data/apiClient.ts
@@ -1,4 +1,4 @@
-import { SERVER_URL, SERVER_TIMEOUT_MS } from './apiConfig';
+import { SERVER_URL, SERVER_TIMEOUT_MS, SERVER_API_KEY } from './apiConfig';
 
 async function fetchWithTimeout(url: string, options?: RequestInit): Promise<Response> {
   const controller = new AbortController();
@@ -13,8 +13,14 @@ async function fetchWithTimeout(url: string, options?: RequestInit): Promise<Res
   }
 }
 
+const baseHeaders = (): Record<string, string> => ({
+  'X-API-Key': SERVER_API_KEY,
+});
+
 async function get<T>(path: string): Promise<T> {
-  const res = await fetchWithTimeout(`${SERVER_URL}${path}`);
+  const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
+    headers: baseHeaders(),
+  });
   if (!res.ok) throw new Error(`HTTP ${res.status}: GET ${path}`);
   return res.json() as Promise<T>;
 }
@@ -22,7 +28,7 @@ async function get<T>(path: string): Promise<T> {
 async function post<T>(path: string, body: unknown): Promise<T> {
   const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { ...baseHeaders(), 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}: POST ${path}`);
@@ -32,7 +38,7 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 async function patch<T>(path: string, body: unknown): Promise<T> {
   const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { ...baseHeaders(), 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}: PATCH ${path}`);
@@ -40,7 +46,10 @@ async function patch<T>(path: string, body: unknown): Promise<T> {
 }
 
 async function del(path: string): Promise<void> {
-  const res = await fetchWithTimeout(`${SERVER_URL}${path}`, { method: 'DELETE' });
+  const res = await fetchWithTimeout(`${SERVER_URL}${path}`, {
+    method: 'DELETE',
+    headers: baseHeaders(),
+  });
   if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}: DELETE ${path}`);
 }
 

--- a/src/data/apiConfig.ts
+++ b/src/data/apiConfig.ts
@@ -1,0 +1,2 @@
+export const SERVER_URL = 'https://api.sweatbridge.xyz';
+export const SERVER_TIMEOUT_MS = 3000;

--- a/src/data/apiConfig.ts
+++ b/src/data/apiConfig.ts
@@ -1,2 +1,3 @@
 export const SERVER_URL = 'https://api.sweatbridge.xyz';
 export const SERVER_TIMEOUT_MS = 3000;
+export const SERVER_API_KEY = process.env.REACT_APP_SERVER_API_KEY ?? '';

--- a/src/data/userToken.ts
+++ b/src/data/userToken.ts
@@ -1,0 +1,47 @@
+const SECRET_HEX = process.env.REACT_APP_USER_TOKEN_SECRET ?? '';
+
+function hexToBytes(hex: string): Uint8Array {
+  const buffer = new ArrayBuffer(hex.length / 2);
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+export async function encryptUserEmail(): Promise<string | null> {
+  const email = localStorage.getItem('userEmail');
+  if (!SECRET_HEX || !email) return null;
+
+  try {
+    const key = await crypto.subtle.importKey(
+      'raw',
+      hexToBytes(SECRET_HEX),
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt']
+    );
+
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encrypted = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      new TextEncoder().encode(email)
+    );
+
+    // Web Crypto AES-GCM returns ciphertext + tag (tag is last 16 bytes)
+    const encryptedBytes = new Uint8Array(encrypted);
+    const ciphertext = encryptedBytes.slice(0, -16);
+    const tag = encryptedBytes.slice(-16);
+
+    // Server expects: iv(12) | tag(16) | ciphertext
+    const combined = new Uint8Array(12 + 16 + ciphertext.length);
+    combined.set(iv, 0);
+    combined.set(tag, 12);
+    combined.set(ciphertext, 28);
+
+    return btoa(Array.from(combined).map(b => String.fromCharCode(b)).join(''));
+  } catch {
+    return null;
+  }
+}

--- a/src/hooks/useAdminBoxes.ts
+++ b/src/hooks/useAdminBoxes.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { BoxInfo, BoxStatus } from '../types/box';
-import { AdminBoxRepository } from '../repositories/adminBoxRepository';
+import { AdminBoxRepository } from '../repositories';
 
 interface AdminBoxesState {
   boxes: BoxInfo[];

--- a/src/hooks/useRevenueManagement.ts
+++ b/src/hooks/useRevenueManagement.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { RevenueState, DailyRevenue } from '../types/revenue';
+import { RevenueState } from '../types/revenue';
 import { RevenueService } from '../services/revenueService';
 
 export const useRevenueManagement = () => {
@@ -81,24 +81,6 @@ export const useRevenueManagement = () => {
     }
   }, [setLoading, setError]);
 
-  // 일별 매출 데이터 업데이트
-  const updateDailyRevenue = useCallback(async (dailyRevenue: DailyRevenue) => {
-    setLoading(true);
-    setError(null);
-    
-    try {
-      await RevenueService.updateDailyRevenue(dailyRevenue);
-      // 현재 월 데이터 다시 로드
-      if (state.monthlyRevenue) {
-        await loadMonthlyRevenue(state.monthlyRevenue.year, state.monthlyRevenue.month);
-      }
-    } catch (error) {
-      setError((error as Error).message);
-      setLoading(false);
-      throw error;
-    }
-  }, [setLoading, setError, loadMonthlyRevenue, state.monthlyRevenue]);
-
   return {
     monthlyRevenue: state.monthlyRevenue,
     stats: state.stats,
@@ -107,7 +89,6 @@ export const useRevenueManagement = () => {
     loadMonthlyRevenue,
     loadRevenueStats,
     loadInitialData,
-    updateDailyRevenue,
     clearError
   };
 }; 

--- a/src/repositories/classRepository.ts
+++ b/src/repositories/classRepository.ts
@@ -2,7 +2,6 @@ import {
   collection,
   deleteDoc,
   doc,
-  getDoc,
   getDocs,
   query,
   setDoc,

--- a/src/repositories/classRepository.ts
+++ b/src/repositories/classRepository.ts
@@ -56,19 +56,6 @@ export class ClassRepository {
   }
 
   /**
-   * 특정 클래스 문서를 조회합니다.
-   *
-   * @param box 박스 이름
-   * @param date 레거시 날짜 경로
-   * @param time 레거시 시간 경로
-   * @returns 클래스 문서 또는 `null`
-   */
-  static async getClass(box: string, date: string, time: string): Promise<FirebaseClassData | null> {
-    const snap = await getDoc(doc(db, `/box/${box}/class/${date}/time`, time));
-    return snap.exists() ? (snap.data() as FirebaseClassData) : null;
-  }
-
-  /**
    * 클래스 문서를 생성합니다.
    *
    * @param box 박스 이름

--- a/src/repositories/coachMemoRepository.ts
+++ b/src/repositories/coachMemoRepository.ts
@@ -1,0 +1,20 @@
+import { doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { db } from '../config/firebase';
+
+const MEMO_DOC_ID = 'coachMemoDoc';
+
+export class CoachMemoRepository {
+  static async getMemo(boxName: string): Promise<string> {
+    const snap = await getDoc(doc(db, `box/${boxName}/dashboardCoachMemos/${MEMO_DOC_ID}`));
+    if (!snap.exists()) return '';
+    return (snap.data() as { coachMemo?: string }).coachMemo ?? '';
+  }
+
+  static async saveMemo(boxName: string, coachMemo: string): Promise<void> {
+    await setDoc(
+      doc(db, `box/${boxName}/dashboardCoachMemos/${MEMO_DOC_ID}`),
+      { coachMemo, updatedAt: serverTimestamp() },
+      { merge: true }
+    );
+  }
+}

--- a/src/repositories/hybrid/hybridAdminBoxRepository.ts
+++ b/src/repositories/hybrid/hybridAdminBoxRepository.ts
@@ -1,0 +1,84 @@
+import { api, serverRead, serverWrite } from '../../data/apiClient';
+import { BoxInfo, BoxStatus } from '../../types/box';
+import { AdminBoxRepository } from '../adminBoxRepository';
+import { ServerBoxRepository } from '../server/serverBoxRepository';
+
+interface ServerBoxListItem {
+  box_name: string;
+  email: string | null;
+  representative: string | null;
+  phone: string | null;
+  zone_code: string | null;
+  road_address: string | null;
+  detail_address: string | null;
+  description: string | null;
+  status: string;
+  member_count: number;
+  coaches: Array<{ name: string; phone: string | null; email: string | null }>;
+}
+
+function toBoxInfo(b: ServerBoxListItem): BoxInfo {
+  return {
+    boxName: b.box_name,
+    email: b.email ?? '',
+    representative: b.representative ?? '',
+    phone: b.phone ?? '',
+    address: {
+      zoneCode: b.zone_code ?? '',
+      roadAddress: b.road_address ?? '',
+      detailAddress: b.detail_address ?? ''
+    },
+    description: b.description ?? '',
+    coaches: b.coaches.map((c) => ({ name: c.name, phone: c.phone ?? '', email: c.email ?? '' })),
+    status: b.status as BoxInfo['status'],
+    memberCount: b.member_count
+  };
+}
+
+export class HybridAdminBoxRepository {
+  // ---- Server-first read ----
+
+  static async listAllBoxes(): Promise<BoxInfo[]> {
+    const serverBoxes = await serverRead(
+      async () => {
+        const list = await api.get<ServerBoxListItem[]>('/api/v1/boxes?limit=200');
+        return list.map(toBoxInfo);
+      },
+      'AdminBox.listAllBoxes'
+    );
+    if (serverBoxes && serverBoxes.length > 0) return serverBoxes;
+    return AdminBoxRepository.listAllBoxes();
+  }
+
+  // ---- Firebase primary + server fire-and-forget ----
+
+  static async updateBoxStatus(boxName: string, status: BoxStatus): Promise<void> {
+    await AdminBoxRepository.updateBoxStatus(boxName, status);
+    serverWrite(
+      () => ServerBoxRepository.updateBox(boxName, { status }),
+      `AdminBox.updateBoxStatus(${boxName})`
+    );
+  }
+
+  static async createBox(boxInfo: BoxInfo): Promise<void> {
+    await AdminBoxRepository.createBox(boxInfo);
+    serverWrite(
+      () => api.post('/api/v1/boxes', {
+        box_name: boxInfo.boxName,
+        email: boxInfo.email || null,
+        representative: boxInfo.representative || null,
+        phone: boxInfo.phone || null,
+        zone_code: boxInfo.address?.zoneCode || null,
+        road_address: boxInfo.address?.roadAddress || null,
+        detail_address: boxInfo.address?.detailAddress || null,
+        description: boxInfo.description || null,
+        coaches: (boxInfo.coaches ?? []).map((c) => ({
+          name: c.name,
+          phone: c.phone || null,
+          email: c.email || null
+        }))
+      }),
+      `AdminBox.createBox(${boxInfo.boxName})`
+    );
+  }
+}

--- a/src/repositories/hybrid/hybridBoxRepository.ts
+++ b/src/repositories/hybrid/hybridBoxRepository.ts
@@ -1,0 +1,42 @@
+import { serverRead, serverWrite } from '../../data/apiClient';
+import { BoxInfo } from '../../types/box';
+import { BoxRepository } from '../boxRepository';
+import { ServerBoxRepository } from '../server/serverBoxRepository';
+
+export class HybridBoxRepository {
+  // ---- Server-first read ----
+
+  static async getBoxInfo(boxName: string): Promise<BoxInfo | null> {
+    const serverBox = await serverRead(
+      () => ServerBoxRepository.getBoxInfo(boxName),
+      `Box.getBoxInfo(${boxName})`
+    );
+    if (serverBox) return serverBox;
+    return BoxRepository.getBoxInfo(boxName);
+  }
+
+  // ---- Firebase primary + server fire-and-forget ----
+
+  static async saveBoxInfo(boxInfo: BoxInfo): Promise<void> {
+    await BoxRepository.saveBoxInfo(boxInfo);
+    serverWrite(
+      () => ServerBoxRepository.updateBox(boxInfo.boxName, {
+        email: boxInfo.email ?? null,
+        representative: boxInfo.representative ?? null,
+        phone: boxInfo.phone ?? null,
+        zone_code: boxInfo.address?.zoneCode ?? null,
+        road_address: boxInfo.address?.roadAddress ?? null,
+        detail_address: boxInfo.address?.detailAddress ?? null,
+        description: boxInfo.description ?? null,
+        status: boxInfo.status ?? null
+      }),
+      `Box.saveBoxInfo(${boxInfo.boxName})`
+    );
+  }
+
+  // ---- Firebase-only (server manages member_count separately) ----
+
+  static adjustMemberCount(boxName: string, delta: number): Promise<void> {
+    return BoxRepository.adjustMemberCount(boxName, delta);
+  }
+}

--- a/src/repositories/hybrid/hybridClassRepository.ts
+++ b/src/repositories/hybrid/hybridClassRepository.ts
@@ -18,12 +18,6 @@ export class HybridClassRepository {
     return ClassRepository.getClassesInRange(box, startDate, endDate);
   }
 
-  // ---- Firebase-only reads ----
-
-  static getClass(box: string, date: string, time: string): Promise<FirebaseClassData | null> {
-    return ClassRepository.getClass(box, date, time);
-  }
-
   // ---- Firebase primary + server fire-and-forget ----
 
   static async setClassDocument(box: string, docKey: string, data: FirebaseClassData): Promise<void> {

--- a/src/repositories/hybrid/hybridClassRepository.ts
+++ b/src/repositories/hybrid/hybridClassRepository.ts
@@ -1,15 +1,24 @@
-import { serverWrite } from '../../data/apiClient';
+import { serverRead, serverWrite } from '../../data/apiClient';
 import { ClassPayload, ClassRepository, FirebaseClassData, FirebaseClassDocument } from '../classRepository';
 import { ServerClassRepository } from '../server/serverClassRepository';
 
 export type { FirebaseClassData, ClassPayload, FirebaseClassDocument };
 
 export class HybridClassRepository {
-  // ---- Firebase-only reads (server lacks `reserved` array) ----
+  // ---- Server-first reads ----
 
-  static getClassesInRange(box: string, startDate: Date, endDate: Date): Promise<FirebaseClassDocument[]> {
+  static async getClassesInRange(box: string, startDate: Date, endDate: Date): Promise<FirebaseClassDocument[]> {
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    const fmt = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    const serverDocs = await serverRead(
+      () => ServerClassRepository.getClassesByRange(box, fmt(startDate), fmt(endDate)),
+      `Class.getClassesInRange(${box})`
+    );
+    if (serverDocs && serverDocs.length > 0) return serverDocs;
     return ClassRepository.getClassesInRange(box, startDate, endDate);
   }
+
+  // ---- Firebase-only reads ----
 
   static getClass(box: string, date: string, time: string): Promise<FirebaseClassData | null> {
     return ClassRepository.getClass(box, date, time);

--- a/src/repositories/hybrid/hybridClassRepository.ts
+++ b/src/repositories/hybrid/hybridClassRepository.ts
@@ -1,0 +1,72 @@
+import { serverWrite } from '../../data/apiClient';
+import { ClassPayload, ClassRepository, FirebaseClassData, FirebaseClassDocument } from '../classRepository';
+import { ServerClassRepository } from '../server/serverClassRepository';
+
+export type { FirebaseClassData, ClassPayload, FirebaseClassDocument };
+
+export class HybridClassRepository {
+  // ---- Firebase-only reads (server lacks `reserved` array) ----
+
+  static getClassesInRange(box: string, startDate: Date, endDate: Date): Promise<FirebaseClassDocument[]> {
+    return ClassRepository.getClassesInRange(box, startDate, endDate);
+  }
+
+  static getClass(box: string, date: string, time: string): Promise<FirebaseClassData | null> {
+    return ClassRepository.getClass(box, date, time);
+  }
+
+  // ---- Firebase primary + server fire-and-forget ----
+
+  static async setClassDocument(box: string, docKey: string, data: FirebaseClassData): Promise<void> {
+    await ClassRepository.setClassDocument(box, docKey, data);
+    serverWrite(async () => {
+      const classDate = data.date.toDate();
+      const pad = (n: number) => n.toString().padStart(2, '0');
+      const dateStr = `${classDate.getFullYear()}-${pad(classDate.getMonth() + 1)}-${pad(classDate.getDate())}T${pad(classDate.getHours())}:${pad(classDate.getMinutes())}:00`;
+      const startTime = `${pad(classDate.getHours())}${pad(classDate.getMinutes())}`;
+      const endTimeMatch = docKey.match(/_(\d{4})$/);
+      const endTime = endTimeMatch ? endTimeMatch[1] : startTime;
+
+      await ServerClassRepository.createClass({
+        box_name: box,
+        doc_key: docKey,
+        class_date: dateStr,
+        start_time: startTime,
+        end_time: endTime,
+        coach: data.coach,
+        cap: data.cap
+      });
+    }, `Class.setClassDocument(${docKey})`);
+  }
+
+  static async updateClassDocument(box: string, docKey: string, data: FirebaseClassData): Promise<void> {
+    await ClassRepository.updateClassDocument(box, docKey, data);
+    serverWrite(async () => {
+      const id = await ServerClassRepository.findClassIdByDocKey(box, docKey);
+      if (id === null) return;
+      const classDate = data.date.toDate();
+      const pad = (n: number) => n.toString().padStart(2, '0');
+      const dateStr = `${classDate.getFullYear()}-${pad(classDate.getMonth() + 1)}-${pad(classDate.getDate())}T${pad(classDate.getHours())}:${pad(classDate.getMinutes())}:00`;
+      const startTime = `${pad(classDate.getHours())}${pad(classDate.getMinutes())}`;
+      const endTimeMatch = docKey.match(/_(\d{4})$/);
+      const endTime = endTimeMatch ? endTimeMatch[1] : startTime;
+      await ServerClassRepository.updateClassById(id, {
+        class_date: dateStr,
+        start_time: startTime,
+        end_time: endTime,
+        coach: data.coach,
+        cap: data.cap
+      });
+    }, `Class.updateClassDocument(${docKey})`);
+  }
+
+  // ---- Firebase primary + server fire-and-forget ----
+
+  static async deleteClassDocument(docKey: string, box: string): Promise<void> {
+    await ClassRepository.deleteClassDocument(docKey, box);
+    serverWrite(async () => {
+      const id = await ServerClassRepository.findClassIdByDocKey(box, docKey);
+      if (id !== null) await ServerClassRepository.deleteClassById(id);
+    }, `Class.deleteClassDocument(${docKey})`);
+  }
+}

--- a/src/repositories/hybrid/hybridCoachMemoRepository.ts
+++ b/src/repositories/hybrid/hybridCoachMemoRepository.ts
@@ -1,0 +1,24 @@
+import { serverRead, serverWrite } from '../../data/apiClient';
+import { CoachMemoRepository } from '../coachMemoRepository';
+import { ServerCoachMemoRepository } from '../server/serverCoachMemoRepository';
+
+export class HybridCoachMemoRepository {
+  // ServerCoachMemoRepository.getMemo는 404도 ''로 반환하므로
+  // null이 아닌 모든 결과(빈 문자열 포함)를 서버 응답으로 채택한다.
+  static async getMemo(boxName: string): Promise<string> {
+    const serverMemo = await serverRead(
+      () => ServerCoachMemoRepository.getMemo(boxName),
+      `CoachMemo.get(${boxName})`
+    );
+    if (serverMemo !== null) return serverMemo;
+    return CoachMemoRepository.getMemo(boxName);
+  }
+
+  static async saveMemo(boxName: string, content: string): Promise<void> {
+    await CoachMemoRepository.saveMemo(boxName, content);
+    serverWrite(
+      () => ServerCoachMemoRepository.upsertMemo(boxName, content),
+      `CoachMemo.upsert(${boxName})`
+    );
+  }
+}

--- a/src/repositories/hybrid/hybridLockerRepository.ts
+++ b/src/repositories/hybrid/hybridLockerRepository.ts
@@ -1,4 +1,4 @@
-import { serverWrite } from '../../data/apiClient';
+import { serverRead, serverWrite } from '../../data/apiClient';
 import { LOCKER_ACTION, LOCKER_STATE, Locker, LockerDocumentData } from '../../types/locker';
 import { LockerRepository } from '../lockerRepository';
 import { ServerLockerRepository } from '../server/serverLockerRepository';
@@ -15,7 +15,14 @@ interface LockerTransactionResult<T> {
 }
 
 export class HybridLockerRepository {
-  static getLockerDocument(box: string): Promise<LockerTransactionContext> {
+  static async getLockerDocument(box: string): Promise<LockerTransactionContext> {
+    const serverMap = await serverRead(
+      () => ServerLockerRepository.getLockerMap(box),
+      `Locker.getLockerDocument(${box})`
+    );
+    if (serverMap && Object.keys(serverMap).length > 0) {
+      return { exists: true, data: serverMap as LockerDocumentData };
+    }
     return LockerRepository.getLockerDocument(box);
   }
 

--- a/src/repositories/hybrid/hybridLockerRepository.ts
+++ b/src/repositories/hybrid/hybridLockerRepository.ts
@@ -1,0 +1,122 @@
+import { serverWrite } from '../../data/apiClient';
+import { LOCKER_ACTION, LOCKER_STATE, Locker, LockerDocumentData } from '../../types/locker';
+import { LockerRepository } from '../lockerRepository';
+import { ServerLockerRepository } from '../server/serverLockerRepository';
+
+interface LockerTransactionContext {
+  exists: boolean;
+  data: LockerDocumentData;
+}
+
+interface LockerTransactionResult<T> {
+  result: T;
+  payload?: Record<string, unknown>;
+  operation?: 'set' | 'update';
+}
+
+export class HybridLockerRepository {
+  static getLockerDocument(box: string): Promise<LockerTransactionContext> {
+    return LockerRepository.getLockerDocument(box);
+  }
+
+  static async runLockerDocumentTransaction<T>(
+    box: string,
+    handler: (context: LockerTransactionContext) => Promise<LockerTransactionResult<T>> | LockerTransactionResult<T>
+  ): Promise<T> {
+    let capturedPayload: Record<string, unknown> | undefined;
+
+    const wrappedHandler = async (context: LockerTransactionContext): Promise<LockerTransactionResult<T>> => {
+      const res = await handler(context);
+      capturedPayload = res.payload;
+      return res;
+    };
+
+    const result = await LockerRepository.runLockerDocumentTransaction(box, wrappedHandler);
+
+    if (capturedPayload && Object.keys(capturedPayload).length > 0) {
+      const payload = capturedPayload;
+      serverWrite(
+        () => syncPayloadToServer(box, payload),
+        `Locker.transaction(${box})`
+      );
+    }
+
+    return result;
+  }
+}
+
+async function syncPayloadToServer(box: string, payload: Record<string, unknown>): Promise<void> {
+  for (const [key, value] of Object.entries(payload)) {
+    const lockerNumber = Number(key);
+    if (!Number.isFinite(lockerNumber)) continue;
+
+    const lastEntry = extractLastEntry(value);
+    if (!lastEntry) continue;
+
+    await syncEntryToServer(box, lockerNumber, lastEntry);
+  }
+}
+
+function extractLastEntry(value: unknown): Partial<Locker> | null {
+  if (Array.isArray(value) && value.length > 0) {
+    return value[value.length - 1] as Partial<Locker>;
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Partial<Locker>;
+  }
+  return null;
+}
+
+async function syncEntryToServer(box: string, lockerNumber: number, entry: Partial<Locker>): Promise<void> {
+  const { action, state } = entry;
+
+  // 신규 락커 추가 (addLockers): action 없음, state = unused, realName 없음
+  if (!action && state === LOCKER_STATE.UNUSED && !entry.realName) {
+    try {
+      await ServerLockerRepository.createLocker({ box_name: box, number: lockerNumber });
+    } catch {
+      // 이미 존재할 수 있으므로 무시
+    }
+    return;
+  }
+
+  if (action === LOCKER_ACTION.ASSIGN) {
+    const lockerId = await ServerLockerRepository.findLockerIdByNumber(box, lockerNumber);
+    if (!lockerId) return;
+    await ServerLockerRepository.assignLocker(lockerId, {
+      user_email: entry.id || '',
+      real_name: entry.realName || '',
+      phone: entry.phone || undefined,
+      start_date: entry.startDate || new Date().toISOString().split('T')[0],
+      end_date: entry.endDate || undefined,
+      locker_key: entry.key || undefined,
+      price: entry.price || undefined,
+      payment_type: entry.paymentType || undefined
+    });
+    return;
+  }
+
+  if (action === LOCKER_ACTION.RELEASE) {
+    const lockerId = await ServerLockerRepository.findLockerIdByNumber(box, lockerNumber);
+    if (lockerId) await ServerLockerRepository.releaseLocker(lockerId);
+    return;
+  }
+
+  if (action === LOCKER_ACTION.DELETE) {
+    const lockerId = await ServerLockerRepository.findLockerIdByNumber(box, lockerNumber);
+    if (lockerId) await ServerLockerRepository.updateLockerState(lockerId, 'deleted');
+    return;
+  }
+
+  if (action === LOCKER_ACTION.MARK_BROKEN) {
+    const lockerId = await ServerLockerRepository.findLockerIdByNumber(box, lockerNumber);
+    if (lockerId) await ServerLockerRepository.updateLockerState(lockerId, 'na');
+    return;
+  }
+
+  if (action === LOCKER_ACTION.RESTORE) {
+    const lockerId = await ServerLockerRepository.findLockerIdByNumber(box, lockerNumber);
+    if (lockerId) await ServerLockerRepository.updateLockerState(lockerId, 'unused');
+    return;
+  }
+}

--- a/src/repositories/hybrid/hybridMemberRepository.ts
+++ b/src/repositories/hybrid/hybridMemberRepository.ts
@@ -29,11 +29,23 @@ export class HybridMemberRepository {
     return MemberRepository.getMemberDocument(box, email);
   }
 
-  static getUsersByField(field: string, value: string): Promise<BoxUser[]> {
+  static async getUsersByField(field: string, value: string): Promise<BoxUser[]> {
+    const serverUsers = await serverRead(async () => {
+      const raw = field === 'phone'
+        ? await ServerUserRepository.getUsersByPhone(value)
+        : await ServerUserRepository.searchUsers(value);
+      return raw.map(toBoxUser);
+    }, `Member.getUsersByField(${field}=${value})`);
+    if (serverUsers && serverUsers.length > 0) return serverUsers;
     return MemberRepository.getUsersByField(field, value);
   }
 
-  static getUserByEmail(email: string): Promise<BoxUser | null> {
+  static async getUserByEmail(email: string): Promise<BoxUser | null> {
+    const serverUser = await serverRead(
+      async () => toBoxUser(await ServerUserRepository.getUserByEmail(email)),
+      `Member.getUserByEmail(${email})`
+    );
+    if (serverUser) return serverUser;
     return MemberRepository.getUserByEmail(email);
   }
 
@@ -204,4 +216,19 @@ export class HybridMemberRepository {
       `User.updateUserStatus(${email})`
     );
   }
+}
+
+import { ServerUserResponse } from '../server/serverUserRepository';
+
+function toBoxUser(u: ServerUserResponse): BoxUser {
+  return {
+    email: u.email,
+    realName: u.real_name,
+    nickName: u.nick_name ?? '',
+    phone: u.phone ?? '',
+    boxName: u.box_name ?? '',
+    status: u.status as BoxStatus,
+    gender: (u.gender as 'M' | 'F') ?? undefined,
+    role: u.role,
+  };
 }

--- a/src/repositories/hybrid/hybridMemberRepository.ts
+++ b/src/repositories/hybrid/hybridMemberRepository.ts
@@ -1,4 +1,4 @@
-import { serverWrite } from '../../data/apiClient';
+import { serverRead, serverWrite } from '../../data/apiClient';
 import { BoxStatus } from '../../types/auth';
 import { BoxUser, MemberApplicantRecord } from '../../types/member';
 import { FirebaseMemberData, FirebaseMemberDocument, MemberRepository } from '../memberRepository';
@@ -9,13 +9,23 @@ import { ServerAppliedRepository } from '../server/serverAppliedRepository';
 export type { FirebaseMemberData, FirebaseMemberDocument };
 
 export class HybridMemberRepository {
-  // ---- Firebase-only reads (server lacks embedded memberships/lockerHistory) ----
+  // ---- Server-first reads ----
 
-  static getMemberDocuments(box: string): Promise<FirebaseMemberDocument[]> {
+  static async getMemberDocuments(box: string): Promise<FirebaseMemberDocument[]> {
+    const serverDocs = await serverRead(
+      () => ServerMemberRepository.listMembersWithDetail(box),
+      `Member.getMemberDocuments(${box})`
+    );
+    if (serverDocs && serverDocs.length > 0) return serverDocs;
     return MemberRepository.getMemberDocuments(box);
   }
 
-  static getMemberDocument(box: string, email: string): Promise<Record<string, unknown> | null> {
+  static async getMemberDocument(box: string, email: string): Promise<Record<string, unknown> | null> {
+    const serverDoc = await serverRead(
+      () => ServerMemberRepository.getMemberWithDetail(box, email),
+      `Member.getMemberDocument(${box}/${email})`
+    );
+    if (serverDoc) return serverDoc;
     return MemberRepository.getMemberDocument(box, email);
   }
 
@@ -27,7 +37,21 @@ export class HybridMemberRepository {
     return MemberRepository.getUserByEmail(email);
   }
 
-  static getApplicantMap(boxName: string): Promise<Record<string, MemberApplicantRecord> | null> {
+  static async getApplicantMap(boxName: string): Promise<Record<string, MemberApplicantRecord> | null> {
+    const serverList = await serverRead(
+      () => ServerAppliedRepository.listPending(boxName),
+      `Member.getApplicantMap(${boxName})`
+    );
+    if (serverList && serverList.length > 0) {
+      return Object.fromEntries(
+        serverList.map((a) => [a.email, {
+          email: a.email,
+          realName: a.real_name,
+          phone: a.phone ?? undefined,
+          birth: a.birth ?? undefined
+        }])
+      );
+    }
     return MemberRepository.getApplicantMap(boxName);
   }
 

--- a/src/repositories/hybrid/hybridMemberRepository.ts
+++ b/src/repositories/hybrid/hybridMemberRepository.ts
@@ -3,7 +3,7 @@ import { BoxStatus } from '../../types/auth';
 import { BoxUser, MemberApplicantRecord } from '../../types/member';
 import { FirebaseMemberData, FirebaseMemberDocument, MemberRepository } from '../memberRepository';
 import { ServerMemberRepository } from '../server/serverMemberRepository';
-import { ServerUserRepository } from '../server/serverUserRepository';
+import { ServerUserRepository, ServerUserResponse } from '../server/serverUserRepository';
 import { ServerAppliedRepository } from '../server/serverAppliedRepository';
 
 export type { FirebaseMemberData, FirebaseMemberDocument };
@@ -217,8 +217,6 @@ export class HybridMemberRepository {
     );
   }
 }
-
-import { ServerUserResponse } from '../server/serverUserRepository';
 
 function toBoxUser(u: ServerUserResponse): BoxUser {
   return {

--- a/src/repositories/hybrid/hybridMemberRepository.ts
+++ b/src/repositories/hybrid/hybridMemberRepository.ts
@@ -1,0 +1,183 @@
+import { serverWrite } from '../../data/apiClient';
+import { BoxStatus } from '../../types/auth';
+import { BoxUser, MemberApplicantRecord } from '../../types/member';
+import { FirebaseMemberData, FirebaseMemberDocument, MemberRepository } from '../memberRepository';
+import { ServerMemberRepository } from '../server/serverMemberRepository';
+import { ServerUserRepository } from '../server/serverUserRepository';
+import { ServerAppliedRepository } from '../server/serverAppliedRepository';
+
+export type { FirebaseMemberData, FirebaseMemberDocument };
+
+export class HybridMemberRepository {
+  // ---- Firebase-only reads (server lacks embedded memberships/lockerHistory) ----
+
+  static getMemberDocuments(box: string): Promise<FirebaseMemberDocument[]> {
+    return MemberRepository.getMemberDocuments(box);
+  }
+
+  static getMemberDocument(box: string, email: string): Promise<Record<string, unknown> | null> {
+    return MemberRepository.getMemberDocument(box, email);
+  }
+
+  static getUsersByField(field: string, value: string): Promise<BoxUser[]> {
+    return MemberRepository.getUsersByField(field, value);
+  }
+
+  static getUserByEmail(email: string): Promise<BoxUser | null> {
+    return MemberRepository.getUserByEmail(email);
+  }
+
+  static getApplicantMap(boxName: string): Promise<Record<string, MemberApplicantRecord> | null> {
+    return MemberRepository.getApplicantMap(boxName);
+  }
+
+  // ---- Firebase primary writes + server fire-and-forget ----
+
+  static async deleteMember(box: string, email: string): Promise<void> {
+    await MemberRepository.deleteMember(box, email);
+    serverWrite(async () => {
+      const member = await ServerMemberRepository.getMemberByEmail(box, email).catch(() => null);
+      if (member) await ServerMemberRepository.deleteMemberById(member.id);
+    }, `Member.deleteMember(${email})`);
+  }
+
+  static async updateMember(box: string, email: string, payload: Record<string, unknown>): Promise<void> {
+    await MemberRepository.updateMember(box, email, payload);
+    serverWrite(async () => {
+      const member = await ServerMemberRepository.getMemberByEmail(box, email).catch(() => null);
+      if (!member) return;
+      await ServerMemberRepository.updateMemberById(member.id, {
+        real_name: payload.realName as string | undefined ?? undefined,
+        nick_name: payload.nickName as string | null | undefined,
+        gender: payload.gender as string | null | undefined,
+        birth_date: payload.birthDate as string | null | undefined,
+        phone: payload.phone as string | null | undefined,
+        memo: payload.memo as string | null | undefined
+      });
+    }, `Member.updateMember(${email})`);
+  }
+
+  static async setMember(box: string, email: string, payload: Record<string, unknown>): Promise<void> {
+    await MemberRepository.setMember(box, email, payload);
+    serverWrite(async () => {
+      const existing = await ServerMemberRepository.getMemberByEmail(box, email).catch(() => null);
+      if (existing) {
+        await ServerMemberRepository.updateMemberById(existing.id, {
+          real_name: payload.realName as string | undefined ?? undefined,
+          nick_name: payload.nickName as string | null | undefined,
+          gender: payload.gender as string | null | undefined,
+          birth_date: payload.birthDate as string | null | undefined,
+          phone: payload.phone as string | null | undefined,
+          memo: payload.memo as string | null | undefined
+        });
+      } else {
+        await ServerMemberRepository.createMember({
+          box_name: box,
+          email,
+          real_name: (payload.realName as string) || '',
+          nick_name: (payload.nickName as string | null) ?? null,
+          gender: (payload.gender as string | null) ?? null,
+          birth_date: (payload.birthDate as string | null) ?? null,
+          phone: (payload.phone as string | null) ?? null,
+          memo: (payload.memo as string | null) ?? null
+        });
+      }
+    }, `Member.setMember(${email})`);
+  }
+
+  static async addMember(box: string, memberData: FirebaseMemberData): Promise<void> {
+    await MemberRepository.addMember(box, memberData);
+    serverWrite(
+      () => ServerMemberRepository.createMember({
+        box_name: box,
+        email: memberData.email,
+        real_name: memberData.realName,
+        nick_name: memberData.nickName ?? null,
+        gender: memberData.gender ?? null,
+        birth_date: memberData.birthDate ?? null,
+        phone: memberData.phone ?? null
+      }),
+      `Member.addMember(${memberData.email})`
+    );
+  }
+
+  // ---- Firebase primary + server fire-and-forget (user collection) ----
+
+  static async updateUsersByEmail(
+    email: string,
+    userData: Partial<BoxUser>
+  ): Promise<Partial<BoxUser> | null> {
+    const result = await MemberRepository.updateUsersByEmail(email, userData);
+    serverWrite(
+      () => ServerUserRepository.updateUser(email, {
+        real_name: userData.realName ?? undefined,
+        nick_name: userData.nickName ?? undefined,
+        phone: userData.phone ?? undefined,
+        gender: userData.gender ?? undefined,
+        birth: userData.birth ?? userData.birthDate ?? undefined,
+        box_name: userData.boxName ?? undefined,
+        role: userData.role ?? undefined,
+        status: userData.status ?? undefined,
+      }),
+      `User.updateUsersByEmail(${email})`
+    );
+    return result;
+  }
+
+  static async deleteApplication(email: string, boxName: string): Promise<void> {
+    await MemberRepository.deleteApplication(email, boxName);
+    serverWrite(async () => {
+      const applied = await ServerAppliedRepository.findByEmail(boxName, email);
+      if (applied) await ServerAppliedRepository.deleteApplied(applied.id);
+    }, `User.deleteApplication(${email})`);
+  }
+
+  static async updateUserBoxName(email: string, boxName: string): Promise<void> {
+    await MemberRepository.updateUserBoxName(email, boxName);
+    serverWrite(
+      () => ServerUserRepository.updateUser(email, { box_name: boxName }),
+      `User.updateUserBoxName(${email})`
+    );
+  }
+
+  static async commitApproveApplicantBatch(
+    email: string,
+    boxName: string,
+    memberData: Record<string, unknown>
+  ): Promise<void> {
+    await MemberRepository.commitApproveApplicantBatch(email, boxName, memberData);
+    serverWrite(
+      () => ServerMemberRepository.createMember({
+        box_name: boxName,
+        email,
+        real_name: (memberData.realName as string) || '',
+        nick_name: (memberData.nickName as string | null) ?? null,
+        gender: (memberData.gender as string | null) ?? null,
+        birth_date: (memberData.birthDate as string | null) ?? null,
+        phone: (memberData.phone as string | null) ?? null,
+        memo: (memberData.memo as string | null) ?? null
+      }),
+      `Member.commitApproveApplicantBatch(${email})`
+    );
+  }
+
+  static commitRejectApplicantBatch(email: string, boxName: string): Promise<void> {
+    return MemberRepository.commitRejectApplicantBatch(email, boxName);
+  }
+
+  static async updateUserBoxInfo(email: string, boxName: string, status: BoxStatus): Promise<void> {
+    await MemberRepository.updateUserBoxInfo(email, boxName, status);
+    serverWrite(
+      () => ServerUserRepository.updateUser(email, { box_name: boxName, status }),
+      `User.updateUserBoxInfo(${email})`
+    );
+  }
+
+  static async updateUserStatus(email: string, status: BoxStatus): Promise<void> {
+    await MemberRepository.updateUserStatus(email, status);
+    serverWrite(
+      () => ServerUserRepository.updateUser(email, { status }),
+      `User.updateUserStatus(${email})`
+    );
+  }
+}

--- a/src/repositories/hybrid/hybridMembershipRepository.ts
+++ b/src/repositories/hybrid/hybridMembershipRepository.ts
@@ -1,0 +1,119 @@
+import { serverRead, serverWrite } from '../../data/apiClient';
+import { MembershipPlan } from '../../types/membership';
+import { RevenueData } from '../../types/revenue';
+import { MemberMembershipDocument, MembershipRepository } from '../membershipRepository';
+import { ServerMembershipRepository } from '../server/serverMembershipRepository';
+import { ServerRevenueRepository } from '../server/serverRevenueRepository';
+
+export type { MemberMembershipDocument };
+
+export class HybridMembershipRepository {
+  // ---- Server-first read ----
+
+  static async getMembershipPlans(boxName: string): Promise<MembershipPlan[]> {
+    const serverPlans = await serverRead(
+      () => ServerMembershipRepository.getMembershipPlans(boxName),
+      `Membership.getMembershipPlans(${boxName})`
+    );
+    if (serverPlans && serverPlans.length > 0) return serverPlans;
+    return MembershipRepository.getMembershipPlans(boxName);
+  }
+
+  // ---- Firebase primary + server fire-and-forget ----
+
+  static async setMembershipPlans(boxName: string, plans: MembershipPlan[]): Promise<void> {
+    await MembershipRepository.setMembershipPlans(boxName, plans);
+    serverWrite(
+      () => syncPlansToServer(boxName, plans),
+      `Membership.setMembershipPlans(${boxName})`
+    );
+  }
+
+  static async commitAddMembershipBatch(
+    boxName: string,
+    email: string,
+    memberships: unknown[],
+    revenue: { year: number; month: number; key: string; entry: RevenueData }
+  ): Promise<void> {
+    await MembershipRepository.commitAddMembershipBatch(boxName, email, memberships, revenue);
+
+    const newMembership = memberships[memberships.length - 1] as any;
+    if (!newMembership) return;
+
+    serverWrite(async () => {
+      const toIsoOrUndef = (v: any) =>
+        v ? (v instanceof Date ? v.toISOString() : new Date(v.seconds * 1000 || v).toISOString()) : undefined;
+
+      await ServerMembershipRepository.createMembership({
+        box_name: boxName,
+        member_email: email,
+        plan: newMembership.plan ?? '',
+        type: newMembership.type ?? 'periodPass',
+        price: newMembership.purchase?.price ?? 0,
+        paid: newMembership.purchase?.paid ?? 0,
+        payment_type: newMembership.purchase?.paymentType ?? undefined,
+        paid_at: toIsoOrUndef(newMembership.purchase?.at),
+        quota_total: newMembership.quota?.total ?? 0,
+        quota_used: newMembership.quota?.used ?? 0,
+        quota_remaining: newMembership.quota?.remaining ?? 0,
+        start_date: toIsoOrUndef(newMembership.period?.startDate),
+        end_date: toIsoOrUndef(newMembership.period?.endDate),
+        assignee: newMembership.assignee ?? undefined
+      });
+
+      await ServerRevenueRepository.createRevenue({
+        box_name: boxName,
+        year: revenue.year,
+        month: revenue.month,
+        transaction_id: revenue.key,
+        assignee: revenue.entry.assignee || undefined,
+        payment_type: revenue.entry.paymentType,
+        plan: revenue.entry.plan || undefined,
+        price: revenue.entry.price,
+        real_name: revenue.entry.realName || undefined,
+        member_email: revenue.entry.id || undefined,
+        type: revenue.entry.type || undefined,
+        refund_amount: revenue.entry.refundAmount || undefined
+      });
+    }, `Membership.commitAddMembershipBatch(${email})`);
+  }
+
+  // ---- Firebase-only reads/writes ----
+
+  static getRawUserMemberships(boxName: string, email: string): Promise<unknown[]> {
+    return MembershipRepository.getRawUserMemberships(boxName, email);
+  }
+
+  static setUserMemberships(boxName: string, email: string, memberships: unknown[]): Promise<void> {
+    return MembershipRepository.setUserMemberships(boxName, email, memberships);
+  }
+
+  static getAllMemberMemberships(boxName: string): Promise<MemberMembershipDocument[]> {
+    return MembershipRepository.getAllMemberMemberships(boxName);
+  }
+}
+
+async function syncPlansToServer(boxName: string, newPlans: MembershipPlan[]): Promise<void> {
+  const serverPlans = await ServerMembershipRepository.getRawPlans(boxName);
+  const newPlanNames = new Set(newPlans.map((p) => p.plan));
+  const serverPlanNames = new Set(serverPlans.map((p) => p.plan));
+
+  for (const sp of serverPlans) {
+    if (!newPlanNames.has(sp.plan)) {
+      await ServerMembershipRepository.deletePlan(sp.id);
+    }
+  }
+
+  for (const plan of newPlans) {
+    if (!serverPlanNames.has(plan.plan)) {
+      await ServerMembershipRepository.createPlan({
+        box_name: boxName,
+        plan: plan.plan,
+        type: plan.type,
+        count: plan.count || undefined,
+        duration: plan.duration || undefined,
+        price: plan.price
+      });
+    }
+  }
+}

--- a/src/repositories/hybrid/hybridMembershipRepository.ts
+++ b/src/repositories/hybrid/hybridMembershipRepository.ts
@@ -2,7 +2,7 @@ import { serverRead, serverWrite } from '../../data/apiClient';
 import { MembershipPlan } from '../../types/membership';
 import { RevenueData } from '../../types/revenue';
 import { MemberMembershipDocument, MembershipRepository } from '../membershipRepository';
-import { ServerMembershipRepository } from '../server/serverMembershipRepository';
+import { ServerMembershipRepository, ServerMembershipResponse } from '../server/serverMembershipRepository';
 import { ServerRevenueRepository } from '../server/serverRevenueRepository';
 
 export type { MemberMembershipDocument };
@@ -88,9 +88,59 @@ export class HybridMembershipRepository {
     return MembershipRepository.setUserMemberships(boxName, email, memberships);
   }
 
-  static getAllMemberMemberships(boxName: string): Promise<MemberMembershipDocument[]> {
+  static async getAllMemberMemberships(boxName: string): Promise<MemberMembershipDocument[]> {
+    const serverList = await serverRead(
+      () => ServerMembershipRepository.getMembershipsByBox(boxName),
+      `Membership.getAllMemberMemberships(${boxName})`
+    );
+    if (serverList && serverList.length > 0) {
+      const byEmail = new Map<string, unknown[]>();
+      for (const m of serverList) {
+        const list = byEmail.get(m.member_email) ?? [];
+        list.push(toRawMembership(m));
+        byEmail.set(m.member_email, list);
+      }
+      return Array.from(byEmail.entries()).map(([email, memberships]) => ({ email, memberships }));
+    }
     return MembershipRepository.getAllMemberMemberships(boxName);
   }
+}
+
+function toRawMembership(m: ServerMembershipResponse): unknown {
+  return {
+    key: String(m.id),
+    plan: m.plan,
+    type: m.type,
+    assignee: m.assignee ?? '',
+    purchase: {
+      price: m.price,
+      paid: m.paid,
+      paymentType: m.payment_type ?? '',
+      at: m.paid_at,
+    },
+    period: {
+      startDate: m.start_date,
+      endDate: m.end_date,
+      originalEndDate: m.original_end_date,
+    },
+    quota: {
+      total: m.quota_total,
+      used: m.quota_used,
+      remaining: m.quota_remaining,
+    },
+    holds: [],
+    adjustments: [],
+    refund: {
+      isRefunded: m.is_refunded,
+      amount: m.refund_amount,
+      at: m.refunded_at,
+      reason: m.refund_reason,
+    },
+    deleted: m.deleted,
+    deletedAt: m.deleted_at,
+    createdAt: m.created_at,
+    updatedAt: m.updated_at,
+  };
 }
 
 async function syncPlansToServer(boxName: string, newPlans: MembershipPlan[]): Promise<void> {

--- a/src/repositories/hybrid/hybridNoticeRepository.ts
+++ b/src/repositories/hybrid/hybridNoticeRepository.ts
@@ -1,0 +1,84 @@
+import { serverRead, serverWrite } from '../../data/apiClient';
+import { NoticeAuthor, NoticePost, NoticeRepository } from '../noticeRepository';
+import { ServerNoticeRepository, ServerNoticeResponse } from '../server/serverNoticeRepository';
+
+function formatServerDate(iso: string | null | undefined): string {
+  if (!iso) return '-';
+  return new Date(iso)
+    .toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
+    .replace(/\s/g, '')
+    .replace(/\.$/, '');
+}
+
+function toNoticePost(s: ServerNoticeResponse): NoticePost {
+  return {
+    id: s.id,
+    title: s.title || '(제목 없음)',
+    content: s.content || '',
+    authorName: s.author_name || '-',
+    createdAtText: formatServerDate(s.created_at),
+    commentCount: s.comment_count,
+  };
+}
+
+export class HybridNoticeRepository {
+  static async list(boxName: string, maxCount?: number): Promise<NoticePost[]> {
+    const serverPosts = await serverRead(
+      async () => {
+        const list = await ServerNoticeRepository.listByBox(boxName, maxCount ?? 200);
+        return list.map(toNoticePost);
+      },
+      `Notice.list(${boxName})`
+    );
+    if (serverPosts && serverPosts.length > 0) return serverPosts;
+    return NoticeRepository.list(boxName, maxCount);
+  }
+
+  static async create(
+    boxName: string,
+    payload: { title: string; content: string },
+    author: NoticeAuthor
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    const id = await NoticeRepository.create(boxName, payload, author);
+    serverWrite(
+      () => ServerNoticeRepository.createNotice({
+        id,
+        box_name: boxName,
+        title: payload.title,
+        content: payload.content,
+        author_name: author.authorName,
+        author_email: author.authorEmail || null,
+        created_at: now,
+        updated_at: now,
+      }),
+      `Notice.create(${id})`
+    );
+  }
+
+  static async update(
+    boxName: string,
+    noticeId: string,
+    payload: { title: string; content: string; authorName: string }
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    await NoticeRepository.update(boxName, noticeId, payload);
+    serverWrite(
+      () => ServerNoticeRepository.updateNotice(noticeId, {
+        title: payload.title,
+        content: payload.content,
+        author_name: payload.authorName,
+        updated_at: now,
+      }),
+      `Notice.update(${noticeId})`
+    );
+  }
+
+  static async delete(boxName: string, noticeId: string): Promise<void> {
+    await NoticeRepository.delete(boxName, noticeId);
+    serverWrite(
+      () => ServerNoticeRepository.deleteNotice(noticeId),
+      `Notice.delete(${noticeId})`
+    );
+  }
+}

--- a/src/repositories/hybrid/hybridRevenueRepository.ts
+++ b/src/repositories/hybrid/hybridRevenueRepository.ts
@@ -86,7 +86,4 @@ export class HybridRevenueRepository {
     }, `Revenue.updateRevenueEntryField(${key}.${field})`);
   }
 
-  static updateDailyRevenue(boxName: string, dailyRevenue: any): Promise<void> {
-    return RevenueRepository.updateDailyRevenue(boxName, dailyRevenue);
-  }
 }

--- a/src/repositories/hybrid/hybridRevenueRepository.ts
+++ b/src/repositories/hybrid/hybridRevenueRepository.ts
@@ -17,9 +17,19 @@ export class HybridRevenueRepository {
     return RevenueRepository.getRevenueYear(boxName, year);
   }
 
-  // ---- Firebase-only reads ----
-
-  static getAllRevenueYears(boxName: string): Promise<RevenueYearDocument[]> {
+  static async getAllRevenueYears(boxName: string): Promise<RevenueYearDocument[]> {
+    const serverYears = await serverRead(
+      () => ServerRevenueRepository.getRevenueYears(boxName),
+      `Revenue.getAllRevenueYears(${boxName})`
+    );
+    if (serverYears && serverYears.length > 0) {
+      return Promise.all(
+        serverYears.map(async (year) => ({
+          year: String(year),
+          data: await RevenueRepository.getRevenueYear(boxName, year),
+        }))
+      );
+    }
     return RevenueRepository.getAllRevenueYears(boxName);
   }
 
@@ -63,12 +73,6 @@ export class HybridRevenueRepository {
       const id = await ServerRevenueRepository.findRevenueIdByKey(boxName, year, month, key);
       if (id !== null) await ServerRevenueRepository.deleteRevenueById(id);
     }, `Revenue.deleteRevenueEntry(${key})`);
-  }
-
-  // ---- Firebase-only writes ----
-
-  static setRevenueYear(boxName: string, year: number | string, data: RevenueYearData): Promise<void> {
-    return RevenueRepository.setRevenueYear(boxName, year, data);
   }
 
   static async updateRevenueEntryField(

--- a/src/repositories/hybrid/hybridRevenueRepository.ts
+++ b/src/repositories/hybrid/hybridRevenueRepository.ts
@@ -1,0 +1,92 @@
+import { serverRead, serverWrite } from '../../data/apiClient';
+import { RevenueData, RevenueYearData } from '../../types/revenue';
+import { RevenueRepository, RevenueYearDocument } from '../revenueRepository';
+import { ServerRevenueRepository } from '../server/serverRevenueRepository';
+
+export type { RevenueYearDocument };
+
+export class HybridRevenueRepository {
+  // ---- Server-first read ----
+
+  static async getRevenueYear(boxName: string, year: number): Promise<RevenueYearData> {
+    const serverData = await serverRead(
+      () => ServerRevenueRepository.getRevenueYear(boxName, year),
+      `Revenue.getRevenueYear(${boxName}, ${year})`
+    );
+    if (serverData && Object.keys(serverData).length > 0) return serverData;
+    return RevenueRepository.getRevenueYear(boxName, year);
+  }
+
+  // ---- Firebase-only reads ----
+
+  static getAllRevenueYears(boxName: string): Promise<RevenueYearDocument[]> {
+    return RevenueRepository.getAllRevenueYears(boxName);
+  }
+
+  // ---- Firebase primary + server fire-and-forget ----
+
+  static async setRevenueEntry(
+    boxName: string,
+    year: number,
+    month: number,
+    key: string,
+    entry: RevenueData
+  ): Promise<void> {
+    await RevenueRepository.setRevenueEntry(boxName, year, month, key, entry);
+    serverWrite(
+      () => ServerRevenueRepository.createRevenue({
+        box_name: boxName,
+        year,
+        month,
+        transaction_id: key,
+        assignee: entry.assignee || undefined,
+        payment_type: entry.paymentType,
+        plan: entry.plan || undefined,
+        price: entry.price,
+        real_name: entry.realName || undefined,
+        member_email: entry.id || undefined,
+        type: entry.type || undefined,
+        refund_amount: entry.refundAmount || undefined
+      }),
+      `Revenue.setRevenueEntry(${key})`
+    );
+  }
+
+  static async deleteRevenueEntry(
+    boxName: string,
+    year: number,
+    month: number,
+    key: string
+  ): Promise<void> {
+    await RevenueRepository.deleteRevenueEntry(boxName, year, month, key);
+    serverWrite(async () => {
+      const id = await ServerRevenueRepository.findRevenueIdByKey(boxName, year, month, key);
+      if (id !== null) await ServerRevenueRepository.deleteRevenueById(id);
+    }, `Revenue.deleteRevenueEntry(${key})`);
+  }
+
+  // ---- Firebase-only writes ----
+
+  static setRevenueYear(boxName: string, year: number | string, data: RevenueYearData): Promise<void> {
+    return RevenueRepository.setRevenueYear(boxName, year, data);
+  }
+
+  static async updateRevenueEntryField(
+    boxName: string,
+    year: number,
+    month: number,
+    key: string,
+    field: string,
+    value: unknown
+  ): Promise<void> {
+    await RevenueRepository.updateRevenueEntryField(boxName, year, month, key, field, value);
+    serverWrite(async () => {
+      const id = await ServerRevenueRepository.findRevenueIdByKey(boxName, year, month, key);
+      if (id !== null) await ServerRevenueRepository.updateRevenueById(id, { [field]: value } as any);
+    }, `Revenue.updateRevenueEntryField(${key}.${field})`);
+  }
+
+  static updateDailyRevenue(boxName: string, dailyRevenue: any): Promise<void> {
+    return RevenueRepository.updateDailyRevenue(boxName, dailyRevenue);
+  }
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,0 +1,19 @@
+export { HybridMemberRepository as MemberRepository } from './hybrid/hybridMemberRepository';
+export type { FirebaseMemberData, FirebaseMemberDocument } from './hybrid/hybridMemberRepository';
+
+export { HybridMembershipRepository as MembershipRepository } from './hybrid/hybridMembershipRepository';
+export type { MemberMembershipDocument } from './hybrid/hybridMembershipRepository';
+
+export { HybridBoxRepository as BoxRepository } from './hybrid/hybridBoxRepository';
+
+export { HybridRevenueRepository as RevenueRepository } from './hybrid/hybridRevenueRepository';
+export type { RevenueYearDocument } from './hybrid/hybridRevenueRepository';
+
+export { HybridLockerRepository as LockerRepository } from './hybrid/hybridLockerRepository';
+
+export { HybridClassRepository as ClassRepository } from './hybrid/hybridClassRepository';
+export type { FirebaseClassData, ClassPayload, FirebaseClassDocument } from './hybrid/hybridClassRepository';
+
+export { HybridAdminBoxRepository as AdminBoxRepository } from './hybrid/hybridAdminBoxRepository';
+
+export { AuthRepository } from './authRepository';

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -19,4 +19,6 @@ export { HybridAdminBoxRepository as AdminBoxRepository } from './hybrid/hybridA
 export { HybridNoticeRepository as NoticeRepository } from './hybrid/hybridNoticeRepository';
 export type { NoticePost, NoticeAuthor } from './noticeRepository';
 
+export { HybridCoachMemoRepository as CoachMemoRepository } from './hybrid/hybridCoachMemoRepository';
+
 export { AuthRepository } from './authRepository';

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -16,4 +16,7 @@ export type { FirebaseClassData, ClassPayload, FirebaseClassDocument } from './h
 
 export { HybridAdminBoxRepository as AdminBoxRepository } from './hybrid/hybridAdminBoxRepository';
 
+export { HybridNoticeRepository as NoticeRepository } from './hybrid/hybridNoticeRepository';
+export type { NoticePost, NoticeAuthor } from './noticeRepository';
+
 export { AuthRepository } from './authRepository';

--- a/src/repositories/noticeRepository.ts
+++ b/src/repositories/noticeRepository.ts
@@ -1,0 +1,129 @@
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  serverTimestamp,
+  Timestamp,
+  updateDoc,
+} from 'firebase/firestore';
+import { db } from '../config/firebase';
+
+export interface NoticePost {
+  id: string;
+  title: string;
+  content: string;
+  authorName: string;
+  createdAtText: string;
+  commentCount: number;
+}
+
+export interface NoticeAuthor {
+  authorName: string;
+  authorEmail: string;
+}
+
+interface FirestoreNoticeDoc {
+  title?: string;
+  postTitle?: string;
+  content?: string;
+  authorName?: string;
+  authorEmail?: string;
+  createdAt?: unknown;
+  commentCount?: number;
+  comments?: unknown[];
+}
+
+function formatDate(value: unknown): string {
+  if (!value) return '-';
+
+  let parsedDate: Date | null = null;
+
+  if (value instanceof Date) {
+    parsedDate = value;
+  } else if (value instanceof Timestamp) {
+    parsedDate = value.toDate();
+  } else if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toDate' in value &&
+    typeof (value as { toDate: () => Date }).toDate === 'function'
+  ) {
+    parsedDate = (value as { toDate: () => Date }).toDate();
+  }
+
+  if (!parsedDate) return '-';
+
+  return parsedDate
+    .toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
+    .replace(/\s/g, '')
+    .replace(/\.$/, '');
+}
+
+function mapDoc(docSnap: { id: string; data: () => FirestoreNoticeDoc }): NoticePost {
+  const data = docSnap.data();
+  const commentCount =
+    typeof data.commentCount === 'number'
+      ? data.commentCount
+      : Array.isArray(data.comments)
+        ? data.comments.length
+        : 0;
+  return {
+    id: docSnap.id,
+    title: data.title || data.postTitle || '(제목 없음)',
+    content: data.content || '',
+    authorName: data.authorName || '-',
+    createdAtText: formatDate(data.createdAt),
+    commentCount,
+  };
+}
+
+export class NoticeRepository {
+  static async list(boxName: string, maxCount?: number): Promise<NoticePost[]> {
+    const ref = collection(db, `box/${boxName}/notices`);
+    const q = maxCount
+      ? query(ref, orderBy('createdAt', 'desc'), limit(maxCount))
+      : query(ref, orderBy('createdAt', 'desc'));
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map(mapDoc);
+  }
+
+  static async create(
+    boxName: string,
+    payload: { title: string; content: string },
+    author: NoticeAuthor
+  ): Promise<string> {
+    const docRef = await addDoc(collection(db, `box/${boxName}/notices`), {
+      title: payload.title,
+      content: payload.content,
+      authorName: author.authorName,
+      authorEmail: author.authorEmail,
+      commentCount: 0,
+      comments: [],
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    });
+    return docRef.id;
+  }
+
+  static async update(
+    boxName: string,
+    noticeId: string,
+    payload: { title: string; content: string; authorName: string }
+  ): Promise<void> {
+    await updateDoc(doc(db, `box/${boxName}/notices`, noticeId), {
+      title: payload.title,
+      content: payload.content,
+      authorName: payload.authorName,
+      updatedAt: serverTimestamp(),
+    });
+  }
+
+  static async delete(boxName: string, noticeId: string): Promise<void> {
+    await deleteDoc(doc(db, `box/${boxName}/notices`, noticeId));
+  }
+}

--- a/src/repositories/revenueRepository.ts
+++ b/src/repositories/revenueRepository.ts
@@ -122,13 +122,4 @@ export class RevenueRepository {
     });
   }
 
-  /**
-   * 일별 매출 저장 구현을 위한 예약 메서드입니다.
-   *
-   * @param _boxName 박스 이름
-   * @param _dailyRevenue 저장할 일별 매출
-   */
-  static async updateDailyRevenue(_boxName: string, _dailyRevenue: any): Promise<void> {
-    return Promise.resolve();
-  }
 }

--- a/src/repositories/revenueRepository.ts
+++ b/src/repositories/revenueRepository.ts
@@ -40,19 +40,6 @@ export class RevenueRepository {
   }
 
   /**
-   * 특정 연도의 매출 문서를 저장합니다.
-   *
-   * 동시 쓰기 시에도 다른 월/엔트리를 덮어쓰지 않도록 merge 모드를 사용합니다.
-   *
-   * @param boxName 박스 이름
-   * @param year 저장 연도
-   * @param data 저장할 연도 데이터
-   */
-  static async setRevenueYear(boxName: string, year: number | string, data: RevenueYearData): Promise<void> {
-    await setDoc(doc(db, `box/${boxName}/revenue/${year}`), data, { merge: true });
-  }
-
-  /**
    * 매출 문서에 단일 엔트리를 추가/갱신합니다.
    *
    * 연도 문서가 없으면 새로 만들고, 있으면 해당 월의 해당 키만 갱신합니다.

--- a/src/repositories/server/serverAppliedRepository.ts
+++ b/src/repositories/server/serverAppliedRepository.ts
@@ -13,6 +13,10 @@ export interface ServerAppliedResponse {
 }
 
 export class ServerAppliedRepository {
+  static async listPending(boxName: string): Promise<ServerAppliedResponse[]> {
+    return api.get<ServerAppliedResponse[]>(`/api/v1/applied/${encodeURIComponent(boxName)}`);
+  }
+
   static async findByEmail(boxName: string, email: string): Promise<ServerAppliedResponse | null> {
     return api.get<ServerAppliedResponse | null>(
       `/api/v1/applied/${encodeURIComponent(boxName)}/by-email?email=${encodeURIComponent(email)}`

--- a/src/repositories/server/serverAppliedRepository.ts
+++ b/src/repositories/server/serverAppliedRepository.ts
@@ -1,0 +1,25 @@
+import { api } from '../../data/apiClient';
+
+export interface ServerAppliedResponse {
+  id: number;
+  box_name: string;
+  email: string;
+  real_name: string;
+  phone: string | null;
+  birth: string | null;
+  status: string;
+  applied_at: string;
+  processed_at: string | null;
+}
+
+export class ServerAppliedRepository {
+  static async findByEmail(boxName: string, email: string): Promise<ServerAppliedResponse | null> {
+    return api.get<ServerAppliedResponse | null>(
+      `/api/v1/applied/${encodeURIComponent(boxName)}/by-email?email=${encodeURIComponent(email)}`
+    );
+  }
+
+  static async deleteApplied(aid: number): Promise<void> {
+    return api.delete(`/api/v1/applied/${aid}`);
+  }
+}

--- a/src/repositories/server/serverBoxRepository.ts
+++ b/src/repositories/server/serverBoxRepository.ts
@@ -1,0 +1,61 @@
+import { api } from '../../data/apiClient';
+import { BoxInfo, Coach } from '../../types/box';
+
+interface ServerBoxResponse {
+  box_name: string;
+  email: string | null;
+  representative: string | null;
+  phone: string | null;
+  zone_code: string | null;
+  road_address: string | null;
+  detail_address: string | null;
+  description: string | null;
+  status: string;
+  member_count: number;
+  coaches: Array<{ name: string; phone: string | null; email: string | null }>;
+  onboarded_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ServerBoxUpdate {
+  email?: string | null;
+  representative?: string | null;
+  phone?: string | null;
+  zone_code?: string | null;
+  road_address?: string | null;
+  detail_address?: string | null;
+  description?: string | null;
+  status?: string | null;
+}
+
+function toBoxInfo(box: ServerBoxResponse): BoxInfo {
+  return {
+    boxName: box.box_name,
+    email: box.email ?? '',
+    representative: box.representative ?? '',
+    phone: box.phone ?? '',
+    address: {
+      zoneCode: box.zone_code ?? '',
+      roadAddress: box.road_address ?? '',
+      detailAddress: box.detail_address ?? ''
+    },
+    description: box.description ?? '',
+    coaches: box.coaches.map(
+      (c): Coach => ({ name: c.name, phone: c.phone ?? '', email: c.email ?? '' })
+    ),
+    status: box.status as BoxInfo['status'],
+    memberCount: box.member_count
+  };
+}
+
+export class ServerBoxRepository {
+  static async getBoxInfo(boxName: string): Promise<BoxInfo> {
+    const box = await api.get<ServerBoxResponse>(`/api/v1/boxes/${encodeURIComponent(boxName)}`);
+    return toBoxInfo(box);
+  }
+
+  static async updateBox(boxName: string, payload: ServerBoxUpdate): Promise<void> {
+    await api.patch(`/api/v1/boxes/${encodeURIComponent(boxName)}`, payload);
+  }
+}

--- a/src/repositories/server/serverClassRepository.ts
+++ b/src/repositories/server/serverClassRepository.ts
@@ -1,0 +1,97 @@
+import { Timestamp } from 'firebase/firestore';
+import { api } from '../../data/apiClient';
+import { FirebaseClassData, FirebaseClassDocument } from '../classRepository';
+
+interface ServerClassResponse {
+  id: number;
+  box_name: string;
+  doc_key: string;
+  class_date: string;
+  start_time: string;
+  end_time: string;
+  coach: string;
+  cap: number;
+  reserved_count: number;
+  created_at: string;
+}
+
+interface ServerClassCreate {
+  box_name: string;
+  doc_key: string;
+  class_date: string;
+  start_time: string;
+  end_time: string;
+  coach: string;
+  cap: number;
+}
+
+export class ServerClassRepository {
+  static async getClassesByMonth(
+    boxName: string,
+    year: number,
+    month: number
+  ): Promise<FirebaseClassDocument[]> {
+    const classes = await api.get<ServerClassResponse[]>(
+      `/api/v1/classes/by-month?box_name=${encodeURIComponent(boxName)}&year=${year}&month=${month}`
+    );
+    return classes.map((c) => ({
+      docKey: c.doc_key,
+      data: {
+        cap: c.cap,
+        coach: c.coach,
+        date: Timestamp.fromDate(new Date(c.class_date)),
+        reserved: []
+      } as FirebaseClassData
+    }));
+  }
+
+  static async createClass(payload: ServerClassCreate): Promise<ServerClassResponse> {
+    return api.post<ServerClassResponse>('/api/v1/classes', payload);
+  }
+
+  static async findClassIdByDocKey(boxName: string, docKey: string): Promise<number | null> {
+    const date = docKeyToDate(docKey);
+    if (!date) return null;
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const classes = await api.get<ServerClassResponse[]>(
+      `/api/v1/classes/by-month?box_name=${encodeURIComponent(boxName)}&year=${year}&month=${month}`
+    );
+    return classes.find((c) => c.doc_key === docKey)?.id ?? null;
+  }
+
+  static async updateClassById(id: number, payload: Partial<Pick<ServerClassCreate, 'class_date' | 'start_time' | 'end_time' | 'coach' | 'cap'>>): Promise<void> {
+    await api.patch(`/api/v1/classes/${id}`, payload);
+  }
+
+  static async getClassesByRange(
+    boxName: string,
+    start: string,
+    end: string
+  ): Promise<FirebaseClassDocument[]> {
+    const classes = await api.get<ServerClassResponse[]>(
+      `/api/v1/classes/by-range?box_name=${encodeURIComponent(boxName)}&start=${start}&end=${end}`
+    );
+    return classes.map((c) => ({
+      docKey: c.doc_key,
+      data: {
+        cap: c.cap,
+        coach: c.coach,
+        date: Timestamp.fromDate(new Date(c.class_date)),
+        reserved: []
+      } as FirebaseClassData
+    }));
+  }
+
+  static async deleteClassById(id: number): Promise<void> {
+    await api.delete(`/api/v1/classes/${id}`);
+  }
+}
+
+function docKeyToDate(docKey: string): Date | null {
+  // format: YYYYMMDDHHMM_HHMM  e.g. 202605251100_1200
+  const match = docKey.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})/);
+  if (!match) return null;
+  const [, year, month, day, hour, minute] = match;
+  return new Date(`${year}-${month}-${day}T${hour}:${minute}:00`);
+}

--- a/src/repositories/server/serverClassRepository.ts
+++ b/src/repositories/server/serverClassRepository.ts
@@ -69,8 +69,8 @@ export class ServerClassRepository {
     start: string,
     end: string
   ): Promise<FirebaseClassDocument[]> {
-    const classes = await api.get<ServerClassResponse[]>(
-      `/api/v1/classes/by-range?box_name=${encodeURIComponent(boxName)}&start=${start}&end=${end}`
+    const classes = await api.get<Array<ServerClassResponse & { reserved?: Array<{ email: string }> }>>(
+      `/api/v1/classes/by-range?box_name=${encodeURIComponent(boxName)}&start=${start}&end=${end}&include_reservations=true`
     );
     return classes.map((c) => ({
       docKey: c.doc_key,
@@ -78,7 +78,7 @@ export class ServerClassRepository {
         cap: c.cap,
         coach: c.coach,
         date: Timestamp.fromDate(new Date(c.class_date)),
-        reserved: []
+        reserved: (c.reserved ?? []).map((r) => r.email)
       } as FirebaseClassData
     }));
   }

--- a/src/repositories/server/serverCoachMemoRepository.ts
+++ b/src/repositories/server/serverCoachMemoRepository.ts
@@ -1,0 +1,29 @@
+import { api } from '../../data/apiClient';
+
+interface ServerCoachMemoResponse {
+  box_name: string;
+  content: string | null;
+  updated_at: string;
+}
+
+export class ServerCoachMemoRepository {
+  // 404 = 메모 없음 → 빈 문자열 반환 (throw 하지 않음)
+  static async getMemo(boxName: string): Promise<string> {
+    try {
+      const res = await api.get<ServerCoachMemoResponse>(
+        `/api/v1/coach-memos/${encodeURIComponent(boxName)}`
+      );
+      return res.content ?? '';
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('HTTP 404')) return '';
+      throw err;
+    }
+  }
+
+  static async upsertMemo(boxName: string, content: string): Promise<void> {
+    await api.put<ServerCoachMemoResponse>(
+      `/api/v1/coach-memos/${encodeURIComponent(boxName)}`,
+      { content }
+    );
+  }
+}

--- a/src/repositories/server/serverLockerRepository.ts
+++ b/src/repositories/server/serverLockerRepository.ts
@@ -1,4 +1,5 @@
 import { api } from '../../data/apiClient';
+import { Locker } from '../../types/locker';
 
 export interface ServerLockerResponse {
   id: number;
@@ -39,6 +40,15 @@ export class ServerLockerRepository {
     );
   }
 
+  static async getLockerMap(boxName: string): Promise<Record<string, Partial<Locker>>> {
+    const map = await api.get<Record<string, ServerLockerResponse>>(
+      `/api/v1/lockers?box_name=${encodeURIComponent(boxName)}&format=map`
+    );
+    return Object.fromEntries(
+      Object.entries(map).map(([key, l]) => [key, serverLockerToPartial(l)])
+    );
+  }
+
   static async findLockerIdByNumber(boxName: string, number: number): Promise<number | null> {
     const lockers = await this.listLockers(boxName);
     return lockers.find((l) => l.number === number)?.id ?? null;
@@ -59,4 +69,21 @@ export class ServerLockerRepository {
   static async updateLockerState(lockerId: number, state: 'unused' | 'na' | 'deleted'): Promise<void> {
     await api.patch(`/api/v1/lockers/${lockerId}`, { state });
   }
+}
+
+function serverLockerToPartial(l: ServerLockerResponse): Partial<Locker> {
+  return {
+    number: l.number,
+    state: l.state as Locker['state'],
+    id: l.user_email ?? '',
+    realName: l.real_name ?? '',
+    phone: l.phone ?? '',
+    assignee: l.assignee ?? '',
+    note: l.note ?? '',
+    startDate: l.start_date ?? '',
+    endDate: l.end_date ?? '',
+    key: l.locker_key ?? undefined,
+    price: l.price ?? undefined,
+    paymentType: (l.payment_type as Locker['paymentType']) ?? undefined,
+  };
 }

--- a/src/repositories/server/serverLockerRepository.ts
+++ b/src/repositories/server/serverLockerRepository.ts
@@ -1,0 +1,62 @@
+import { api } from '../../data/apiClient';
+
+export interface ServerLockerResponse {
+  id: number;
+  box_name: string;
+  number: number;
+  state: string;
+  user_email: string | null;
+  real_name: string | null;
+  phone: string | null;
+  assignee: string | null;
+  note: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  locker_key: string | null;
+  price: string | null;
+  payment_type: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ServerLockerAssign {
+  user_email: string;
+  real_name: string;
+  phone?: string;
+  assignee?: string;
+  note?: string;
+  start_date: string;
+  end_date?: string;
+  locker_key?: string;
+  price?: string;
+  payment_type?: string;
+}
+
+export class ServerLockerRepository {
+  static async listLockers(boxName: string): Promise<ServerLockerResponse[]> {
+    return api.get<ServerLockerResponse[]>(
+      `/api/v1/lockers?box_name=${encodeURIComponent(boxName)}`
+    );
+  }
+
+  static async findLockerIdByNumber(boxName: string, number: number): Promise<number | null> {
+    const lockers = await this.listLockers(boxName);
+    return lockers.find((l) => l.number === number)?.id ?? null;
+  }
+
+  static async createLocker(payload: { box_name: string; number: number; state?: string }): Promise<void> {
+    await api.post('/api/v1/lockers', { state: 'unused', ...payload });
+  }
+
+  static async assignLocker(lockerId: number, payload: ServerLockerAssign): Promise<void> {
+    await api.post(`/api/v1/lockers/${lockerId}/assign`, payload);
+  }
+
+  static async releaseLocker(lockerId: number): Promise<void> {
+    await api.post(`/api/v1/lockers/${lockerId}/release`, {});
+  }
+
+  static async updateLockerState(lockerId: number, state: 'unused' | 'na' | 'deleted'): Promise<void> {
+    await api.patch(`/api/v1/lockers/${lockerId}`, { state });
+  }
+}

--- a/src/repositories/server/serverMemberRepository.ts
+++ b/src/repositories/server/serverMemberRepository.ts
@@ -1,4 +1,45 @@
 import { api } from '../../data/apiClient';
+import { FirebaseMemberDocument } from '../memberRepository';
+
+export interface ServerMembershipDetail {
+  id: number;
+  plan: string;
+  type: string;
+  price: number;
+  paid: number;
+  payment_type: string | null;
+  paid_at: string | null;
+  quota_total: number;
+  quota_used: number;
+  quota_remaining: number;
+  start_date: string | null;
+  end_date: string | null;
+  original_end_date: string | null;
+  assignee: string | null;
+  is_future: boolean;
+  deleted: boolean;
+  deleted_at: string | null;
+  is_refunded: boolean;
+  refund_amount: number;
+  refund_reason: string | null;
+  refunded_at: string | null;
+  refund_assignee: string | null;
+  box_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ServerLockerHistoryDetail {
+  id: number;
+  locker_num: number;
+  start_date: string;
+  end_date: string | null;
+  released_date: string | null;
+  locker_key: string | null;
+  price: string | null;
+  payment_type: string | null;
+  created_at: string;
+}
 
 export interface ServerMemberResponse {
   id: number;
@@ -14,6 +55,11 @@ export interface ServerMemberResponse {
   joined_at: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface ServerMemberDetailResponse extends ServerMemberResponse {
+  memberships: ServerMembershipDetail[];
+  locker_history: ServerLockerHistoryDetail[];
 }
 
 export interface ServerMemberCreate {
@@ -43,10 +89,28 @@ export class ServerMemberRepository {
     );
   }
 
+  static async listMembersWithDetail(boxName: string): Promise<FirebaseMemberDocument[]> {
+    const members = await api.get<ServerMemberDetailResponse[]>(
+      `/api/v1/members?box_name=${encodeURIComponent(boxName)}&limit=500&with_detail=true`
+    );
+    return members.map(serverMemberDetailToFirebaseDocument);
+  }
+
   static async getMemberByEmail(boxName: string, email: string): Promise<ServerMemberResponse> {
     return api.get<ServerMemberResponse>(
       `/api/v1/members/by-email?box_name=${encodeURIComponent(boxName)}&email=${encodeURIComponent(email)}`
     );
+  }
+
+  static async getMemberWithDetail(boxName: string, email: string): Promise<Record<string, unknown> | null> {
+    try {
+      const m = await api.get<ServerMemberDetailResponse>(
+        `/api/v1/members/by-email?box_name=${encodeURIComponent(boxName)}&email=${encodeURIComponent(email)}&with_detail=true`
+      );
+      return serverMemberDetailToFirebaseDocument(m).data;
+    } catch {
+      return null;
+    }
   }
 
   static async createMember(payload: ServerMemberCreate): Promise<ServerMemberResponse> {
@@ -60,4 +124,76 @@ export class ServerMemberRepository {
   static async deleteMemberById(id: number): Promise<void> {
     return api.delete(`/api/v1/members/${id}`);
   }
+}
+
+function serverMemberDetailToFirebaseDocument(m: ServerMemberDetailResponse): FirebaseMemberDocument {
+  return {
+    id: m.email,
+    data: {
+      email: m.email,
+      realName: m.real_name,
+      nickName: m.nick_name ?? '',
+      gender: m.gender ?? '',
+      birthDate: m.birth_date ?? '',
+      birth: m.birth_date ?? '',
+      phone: m.phone ?? '',
+      memo: m.memo ?? '',
+      lockerPass: m.locker_pass ?? '',
+      joinedAt: m.joined_at ?? null,
+      memberships: m.memberships.map(serverMembershipToFirebaseFormat),
+      lockerHistory: m.locker_history.map(serverLockerHistoryToFirebaseFormat),
+    },
+  };
+}
+
+function serverMembershipToFirebaseFormat(ms: ServerMembershipDetail): Record<string, unknown> {
+  return {
+    key: `server-${ms.id}`,
+    plan: ms.plan,
+    type: ms.type,
+    boxName: ms.box_name,
+    assignee: ms.assignee ?? '',
+    deleted: ms.deleted,
+    deletedAt: ms.deleted_at ?? null,
+    purchase: {
+      price: ms.price,
+      paid: ms.paid,
+      paymentType: ms.payment_type ?? '',
+      at: ms.paid_at ?? new Date(0).toISOString(),
+    },
+    quota: {
+      total: ms.quota_total,
+      used: ms.quota_used,
+      remaining: ms.quota_remaining,
+    },
+    period: {
+      startDate: ms.start_date ?? new Date(0).toISOString(),
+      endDate: ms.end_date ?? new Date(0).toISOString(),
+      originalEndDate: ms.original_end_date ?? ms.end_date ?? new Date(0).toISOString(),
+    },
+    holds: [],
+    refund: {
+      isRefunded: ms.is_refunded,
+      at: ms.refunded_at ?? null,
+      refundAmount: ms.refund_amount,
+      reason: ms.refund_reason ?? null,
+      assignee: ms.refund_assignee ?? null,
+    },
+    adjustments: [],
+    createdAt: ms.created_at,
+    updatedAt: ms.updated_at,
+  };
+}
+
+function serverLockerHistoryToFirebaseFormat(lh: ServerLockerHistoryDetail): Record<string, unknown> {
+  return {
+    lockerNum: lh.locker_num,
+    startDate: lh.start_date,
+    endDate: lh.end_date ?? '',
+    releasedDate: lh.released_date ?? undefined,
+    key: `server-${lh.id}`,
+    price: lh.price ?? undefined,
+    paymentType: lh.payment_type ?? undefined,
+    createdAt: lh.created_at,
+  };
 }

--- a/src/repositories/server/serverMemberRepository.ts
+++ b/src/repositories/server/serverMemberRepository.ts
@@ -1,0 +1,63 @@
+import { api } from '../../data/apiClient';
+
+export interface ServerMemberResponse {
+  id: number;
+  box_name: string;
+  email: string;
+  real_name: string;
+  nick_name: string | null;
+  gender: string | null;
+  birth_date: string | null;
+  phone: string | null;
+  memo: string | null;
+  locker_pass: string | null;
+  joined_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ServerMemberCreate {
+  box_name: string;
+  email: string;
+  real_name: string;
+  nick_name?: string | null;
+  gender?: string | null;
+  birth_date?: string | null;
+  phone?: string | null;
+  memo?: string | null;
+}
+
+export interface ServerMemberUpdate {
+  real_name?: string | null;
+  nick_name?: string | null;
+  gender?: string | null;
+  birth_date?: string | null;
+  phone?: string | null;
+  memo?: string | null;
+}
+
+export class ServerMemberRepository {
+  static async listMembers(boxName: string): Promise<ServerMemberResponse[]> {
+    return api.get<ServerMemberResponse[]>(
+      `/api/v1/members?box_name=${encodeURIComponent(boxName)}&limit=500`
+    );
+  }
+
+  static async getMemberByEmail(boxName: string, email: string): Promise<ServerMemberResponse> {
+    return api.get<ServerMemberResponse>(
+      `/api/v1/members/by-email?box_name=${encodeURIComponent(boxName)}&email=${encodeURIComponent(email)}`
+    );
+  }
+
+  static async createMember(payload: ServerMemberCreate): Promise<ServerMemberResponse> {
+    return api.post<ServerMemberResponse>('/api/v1/members', payload);
+  }
+
+  static async updateMemberById(id: number, payload: ServerMemberUpdate): Promise<ServerMemberResponse> {
+    return api.patch<ServerMemberResponse>(`/api/v1/members/${id}`, payload);
+  }
+
+  static async deleteMemberById(id: number): Promise<void> {
+    return api.delete(`/api/v1/members/${id}`);
+  }
+}

--- a/src/repositories/server/serverMemberRepository.ts
+++ b/src/repositories/server/serverMemberRepository.ts
@@ -1,3 +1,4 @@
+import { Timestamp } from 'firebase/firestore';
 import { api } from '../../data/apiClient';
 import { FirebaseMemberDocument } from '../memberRepository';
 
@@ -139,7 +140,7 @@ function serverMemberDetailToFirebaseDocument(m: ServerMemberDetailResponse): Fi
       phone: m.phone ?? '',
       memo: m.memo ?? '',
       lockerPass: m.locker_pass ?? '',
-      joinedAt: m.joined_at ?? null,
+      joinedAt: m.joined_at ? Timestamp.fromDate(new Date(m.joined_at)) : null,
       memberships: m.memberships.map(serverMembershipToFirebaseFormat),
       lockerHistory: m.locker_history.map(serverLockerHistoryToFirebaseFormat),
     },

--- a/src/repositories/server/serverMembershipRepository.ts
+++ b/src/repositories/server/serverMembershipRepository.ts
@@ -11,6 +11,33 @@ interface ServerPlanResponse {
   price: string;
 }
 
+export interface ServerMembershipResponse {
+  id: number;
+  box_name: string;
+  member_email: string;
+  plan: string;
+  type: string;
+  price: number;
+  paid: number;
+  payment_type: string | null;
+  paid_at: string | null;
+  quota_total: number;
+  quota_used: number;
+  quota_remaining: number;
+  start_date: string | null;
+  end_date: string | null;
+  original_end_date: string | null;
+  assignee: string | null;
+  is_refunded: boolean;
+  refund_amount: number;
+  refund_reason: string | null;
+  refunded_at: string | null;
+  deleted: boolean;
+  deleted_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface ServerMembershipCreate {
   box_name: string;
   member_email: string;
@@ -66,6 +93,12 @@ export class ServerMembershipRepository {
   }
 
   // ---- Memberships ----
+
+  static async getMembershipsByBox(boxName: string): Promise<ServerMembershipResponse[]> {
+    return api.get<ServerMembershipResponse[]>(
+      `/api/v1/memberships?box_name=${encodeURIComponent(boxName)}`
+    );
+  }
 
   static async createMembership(payload: ServerMembershipCreate): Promise<void> {
     await api.post('/api/v1/memberships', payload);

--- a/src/repositories/server/serverMembershipRepository.ts
+++ b/src/repositories/server/serverMembershipRepository.ts
@@ -1,0 +1,73 @@
+import { api } from '../../data/apiClient';
+import { MembershipPlan } from '../../types/membership';
+
+interface ServerPlanResponse {
+  id: number;
+  box_name: string;
+  plan: string;
+  type: string;
+  count: string | null;
+  duration: number | null;
+  price: string;
+}
+
+export interface ServerMembershipCreate {
+  box_name: string;
+  member_email: string;
+  plan: string;
+  type: string;
+  price?: number;
+  paid?: number;
+  payment_type?: string;
+  paid_at?: string;
+  quota_total?: number;
+  quota_used?: number;
+  quota_remaining?: number;
+  start_date?: string;
+  end_date?: string;
+  assignee?: string;
+}
+
+export class ServerMembershipRepository {
+  // ---- Plans ----
+
+  static async getMembershipPlans(boxName: string): Promise<MembershipPlan[]> {
+    const plans = await api.get<ServerPlanResponse[]>(
+      `/api/v1/memberships/plans?box_name=${encodeURIComponent(boxName)}`
+    );
+    return plans.map((p) => ({
+      plan: p.plan,
+      type: p.type as MembershipPlan['type'],
+      count: p.count ?? '',
+      duration: p.duration ?? 0,
+      price: p.price
+    }));
+  }
+
+  static async getRawPlans(boxName: string): Promise<ServerPlanResponse[]> {
+    return api.get<ServerPlanResponse[]>(
+      `/api/v1/memberships/plans?box_name=${encodeURIComponent(boxName)}`
+    );
+  }
+
+  static async createPlan(payload: {
+    box_name: string;
+    plan: string;
+    type: string;
+    count?: string;
+    duration?: number;
+    price: string;
+  }): Promise<void> {
+    await api.post('/api/v1/memberships/plans', payload);
+  }
+
+  static async deletePlan(planId: number): Promise<void> {
+    await api.delete(`/api/v1/memberships/plans/${planId}`);
+  }
+
+  // ---- Memberships ----
+
+  static async createMembership(payload: ServerMembershipCreate): Promise<void> {
+    await api.post('/api/v1/memberships', payload);
+  }
+}

--- a/src/repositories/server/serverNoticeRepository.ts
+++ b/src/repositories/server/serverNoticeRepository.ts
@@ -1,0 +1,52 @@
+import { api } from '../../data/apiClient';
+
+export interface ServerNoticeResponse {
+  id: string;
+  box_name: string | null;
+  title: string;
+  content: string | null;
+  author_name: string | null;
+  author_email: string | null;
+  comment_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ServerNoticeCreate {
+  id: string;
+  box_name?: string | null;
+  title: string;
+  content?: string | null;
+  author_name?: string | null;
+  author_email?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ServerNoticeUpdate {
+  title?: string;
+  content?: string;
+  author_name?: string;
+  author_email?: string;
+  updated_at?: string;
+}
+
+export class ServerNoticeRepository {
+  static async listByBox(boxName: string, limit = 50): Promise<ServerNoticeResponse[]> {
+    return api.get<ServerNoticeResponse[]>(
+      `/api/v1/notices?box_name=${encodeURIComponent(boxName)}&limit=${limit}`
+    );
+  }
+
+  static async createNotice(payload: ServerNoticeCreate): Promise<void> {
+    await api.post('/api/v1/notices', payload);
+  }
+
+  static async updateNotice(noticeId: string, payload: ServerNoticeUpdate): Promise<void> {
+    await api.patch(`/api/v1/notices/${encodeURIComponent(noticeId)}`, payload);
+  }
+
+  static async deleteNotice(noticeId: string): Promise<void> {
+    await api.delete(`/api/v1/notices/${encodeURIComponent(noticeId)}`);
+  }
+}

--- a/src/repositories/server/serverRevenueRepository.ts
+++ b/src/repositories/server/serverRevenueRepository.ts
@@ -1,0 +1,90 @@
+import { Timestamp } from 'firebase/firestore';
+import { api } from '../../data/apiClient';
+import { RevenueData, RevenueYearData } from '../../types/revenue';
+
+interface ServerRevenueResponse {
+  id: number;
+  box_name: string;
+  year: number;
+  month: number;
+  transaction_id: string | null;
+  assignee: string | null;
+  payment_type: string;
+  plan: string | null;
+  price: string;
+  real_name: string | null;
+  member_email: string | null;
+  type: string | null;
+  refund_amount: string | null;
+  created_at: string;
+}
+
+interface ServerRevenueCreate {
+  box_name: string;
+  year: number;
+  month: number;
+  transaction_id?: string;
+  assignee?: string;
+  payment_type: string;
+  plan?: string;
+  price: string;
+  real_name?: string;
+  member_email?: string;
+  type?: string;
+  refund_amount?: string;
+}
+
+function toRevenueYearData(revenues: ServerRevenueResponse[]): RevenueYearData {
+  const result: RevenueYearData = {};
+  for (const r of revenues) {
+    const monthKey = r.month.toString();
+    if (!result[monthKey]) result[monthKey] = {};
+    const key = r.transaction_id ?? r.id.toString();
+    result[monthKey][key] = {
+      assignee: r.assignee ?? '',
+      createdAt: Timestamp.fromDate(new Date(r.created_at)),
+      id: r.member_email ?? '',
+      paymentType: r.payment_type as RevenueData['paymentType'],
+      plan: r.plan ?? '',
+      price: r.price,
+      realName: r.real_name ?? '',
+      type: r.type ?? '',
+      refundAmount: r.refund_amount ?? '0'
+    };
+  }
+  return result;
+}
+
+export class ServerRevenueRepository {
+  static async getRevenueYear(boxName: string, year: number): Promise<RevenueYearData> {
+    const revenues = await api.get<ServerRevenueResponse[]>(
+      `/api/v1/revenues/year?box_name=${encodeURIComponent(boxName)}&year=${year}`
+    );
+    return toRevenueYearData(revenues);
+  }
+
+  static async createRevenue(payload: ServerRevenueCreate): Promise<void> {
+    await api.post('/api/v1/revenues', payload);
+  }
+
+  static async updateRevenueById(id: number, payload: Partial<ServerRevenueCreate>): Promise<void> {
+    await api.patch(`/api/v1/revenues/${id}`, payload);
+  }
+
+  static async deleteRevenueById(id: number): Promise<void> {
+    await api.delete(`/api/v1/revenues/${id}`);
+  }
+
+  static async findRevenueIdByKey(
+    boxName: string,
+    year: number,
+    month: number,
+    transactionId: string
+  ): Promise<number | null> {
+    const revenues = await api.get<ServerRevenueResponse[]>(
+      `/api/v1/revenues/month?box_name=${encodeURIComponent(boxName)}&year=${year}&month=${month}`
+    );
+    const match = revenues.find((r) => r.transaction_id === transactionId);
+    return match?.id ?? null;
+  }
+}

--- a/src/repositories/server/serverRevenueRepository.ts
+++ b/src/repositories/server/serverRevenueRepository.ts
@@ -56,6 +56,10 @@ function toRevenueYearData(revenues: ServerRevenueResponse[]): RevenueYearData {
 }
 
 export class ServerRevenueRepository {
+  static async getRevenueYears(boxName: string): Promise<number[]> {
+    return api.get<number[]>(`/api/v1/revenues/years?box_name=${encodeURIComponent(boxName)}`);
+  }
+
   static async getRevenueYear(boxName: string, year: number): Promise<RevenueYearData> {
     const revenues = await api.get<ServerRevenueResponse[]>(
       `/api/v1/revenues/year?box_name=${encodeURIComponent(boxName)}&year=${year}`

--- a/src/repositories/server/serverUserRepository.ts
+++ b/src/repositories/server/serverUserRepository.ts
@@ -1,0 +1,38 @@
+import { api } from '../../data/apiClient';
+
+export interface ServerUserResponse {
+  email: string;
+  real_name: string;
+  nick_name: string | null;
+  phone: string | null;
+  gender: string | null;
+  birth: string | null;
+  box_name: string | null;
+  role: string;
+  status: string;
+}
+
+export interface ServerUserUpdate {
+  real_name?: string | null;
+  nick_name?: string | null;
+  phone?: string | null;
+  gender?: string | null;
+  birth?: string | null;
+  box_name?: string | null;
+  role?: string | null;
+  status?: string | null;
+}
+
+export class ServerUserRepository {
+  static async getUserByEmail(email: string): Promise<ServerUserResponse> {
+    return api.get<ServerUserResponse>(`/api/v1/users/${encodeURIComponent(email)}`);
+  }
+
+  static async updateUser(email: string, payload: ServerUserUpdate): Promise<ServerUserResponse> {
+    return api.patch<ServerUserResponse>(`/api/v1/users/${encodeURIComponent(email)}`, payload);
+  }
+
+  static async deleteUser(email: string): Promise<void> {
+    return api.delete(`/api/v1/users/${encodeURIComponent(email)}`);
+  }
+}

--- a/src/repositories/server/serverUserRepository.ts
+++ b/src/repositories/server/serverUserRepository.ts
@@ -28,6 +28,11 @@ export class ServerUserRepository {
     return api.get<ServerUserResponse>(`/api/v1/users/${encodeURIComponent(email)}`);
   }
 
+  static async getUsersByPhone(phone: string): Promise<ServerUserResponse[]> {
+    const params = new URLSearchParams({ phone });
+    return api.get<ServerUserResponse[]>(`/api/v1/users?${params.toString()}`);
+  }
+
   static async searchUsers(query: string, boxName?: string): Promise<ServerUserResponse[]> {
     const params = new URLSearchParams({ search: query });
     if (boxName) params.set('box_name', boxName);

--- a/src/repositories/server/serverUserRepository.ts
+++ b/src/repositories/server/serverUserRepository.ts
@@ -28,6 +28,12 @@ export class ServerUserRepository {
     return api.get<ServerUserResponse>(`/api/v1/users/${encodeURIComponent(email)}`);
   }
 
+  static async searchUsers(query: string, boxName?: string): Promise<ServerUserResponse[]> {
+    const params = new URLSearchParams({ search: query });
+    if (boxName) params.set('box_name', boxName);
+    return api.get<ServerUserResponse[]>(`/api/v1/users?${params.toString()}`);
+  }
+
   static async updateUser(email: string, payload: ServerUserUpdate): Promise<ServerUserResponse> {
     return api.patch<ServerUserResponse>(`/api/v1/users/${encodeURIComponent(email)}`, payload);
   }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,4 @@
-import { AuthRepository } from '../repositories/authRepository';
+import { AuthRepository } from '../repositories';
 import { BoxStatus, LoginCredentials, User, UserRole } from '../types/auth';
 
 const AUTH_STORAGE_KEYS = [

--- a/src/services/boxService.ts
+++ b/src/services/boxService.ts
@@ -1,4 +1,4 @@
-import { BoxRepository } from '../repositories/boxRepository';
+import { BoxRepository } from '../repositories';
 import { BoxInfo, Coach } from '../types/box';
 import { getCachedCoaches, hasFetchedCoachList, setCachedCoaches } from '../utils/coachStorage';
 

--- a/src/services/classService.ts
+++ b/src/services/classService.ts
@@ -55,18 +55,6 @@ export class ClassService {
   }
 
   /**
-   * 레거시 경로 기준으로 특정 클래스 문서를 조회합니다.
-   *
-   * @param box 박스 이름
-   * @param date 날짜 경로
-   * @param time 시간 경로
-   * @returns 클래스 문서 또는 `null`
-   */
-  static async getClass(box: string, date: string, time: string): Promise<FirebaseClassData | null> {
-    return ClassRepository.getClass(box, date, time);
-  }
-
-  /**
    * 새 클래스 문서를 생성합니다.
    *
    * @param payload 생성할 클래스 정보

--- a/src/services/classService.ts
+++ b/src/services/classService.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from 'firebase/firestore';
 import { extractDateTimeFromDocKey, formatDateTime, generateDocKey } from '../models/classModel';
-import { ClassPayload, ClassRepository, FirebaseClassData, FirebaseClassDocument } from '../repositories/classRepository';
+import { ClassPayload, ClassRepository, FirebaseClassData, FirebaseClassDocument } from '../repositories';
 import { ClassEvent } from '../types/class';
 
 export class ClassService {

--- a/src/services/classService.ts
+++ b/src/services/classService.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from 'firebase/firestore';
 import { extractDateTimeFromDocKey, formatDateTime, generateDocKey } from '../models/classModel';
-import { ClassPayload, ClassRepository, FirebaseClassData, FirebaseClassDocument } from '../repositories';
+import { ClassPayload, ClassRepository, FirebaseClassDocument } from '../repositories';
 import { ClassEvent } from '../types/class';
 
 export class ClassService {

--- a/src/services/dashboardMemoService.ts
+++ b/src/services/dashboardMemoService.ts
@@ -1,51 +1,13 @@
-import { doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore';
-import { db } from '../config/firebase';
-
-const DASHBOARD_MEMO_DOC_ID = 'coachMemoDoc';
-
-interface DashboardMemoDoc {
-  coachMemo?: string;
-  updatedAt?: unknown;
-}
+import { CoachMemoRepository } from '../repositories';
 
 export class DashboardMemoService {
   static async getCoachMemo(boxName: string): Promise<string> {
-    try {
-      if (!boxName) return '';
-
-      const memoRef = doc(db, `box/${boxName}/dashboardCoachMemos/${DASHBOARD_MEMO_DOC_ID}`);
-      const memoSnap = await getDoc(memoRef);
-
-      if (!memoSnap.exists()) {
-        return '';
-      }
-
-      const data = memoSnap.data() as DashboardMemoDoc;
-      return data.coachMemo || '';
-    } catch (error) {
-      console.error('Failed to load coach memo:', error);
-      throw error;
-    }
+    if (!boxName) return '';
+    return CoachMemoRepository.getMemo(boxName);
   }
 
   static async saveCoachMemo(boxName: string, coachMemo: string): Promise<void> {
-    try {
-      if (!boxName) {
-        throw new Error('박스 이름이 없습니다.');
-      }
-
-      const memoRef = doc(db, `box/${boxName}/dashboardCoachMemos/${DASHBOARD_MEMO_DOC_ID}`);
-      await setDoc(
-        memoRef,
-        {
-          coachMemo,
-          updatedAt: serverTimestamp()
-        },
-        { merge: true }
-      );
-    } catch (error) {
-      console.error('Failed to save coach memo:', error);
-      throw error;
-    }
+    if (!boxName) throw new Error('박스 이름이 없습니다.');
+    await CoachMemoRepository.saveMemo(boxName, coachMemo);
   }
 }

--- a/src/services/lockerService.ts
+++ b/src/services/lockerService.ts
@@ -1,7 +1,7 @@
 import { doc, runTransaction, Timestamp } from 'firebase/firestore';
 import { db } from '../config/firebase';
 import { getLatestLocker, hasActiveAssignedUser, toLocker } from '../models/lockerModel';
-import { LockerRepository } from '../repositories/lockerRepository';
+import { LockerRepository } from '../repositories';
 import { Locker, LOCKER_ACTION, LOCKER_STATE, LockerDocumentData, LockerDocumentEntry, LockerState } from '../types/locker';
 import { MemberLockerHistory } from '../types/member';
 import { formatDateToString } from '../utils/dateUtils';

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -4,8 +4,8 @@ import {
   categorizeMemberships,
   convertMembershipsFromFirebase
 } from '../models/memberModel';
-import { FirebaseMemberData, MemberRepository } from '../repositories/memberRepository';
-import { BoxRepository } from '../repositories/boxRepository';
+import { FirebaseMemberData, MemberRepository } from '../repositories';
+import { BoxRepository } from '../repositories';
 import { BoxUser, Member, MemberApplicant, MemberLockerHistory } from '../types/member';
 
 export class MemberService {

--- a/src/services/membershipService.ts
+++ b/src/services/membershipService.ts
@@ -12,7 +12,7 @@ import {
   isValidActiveMembership,
   isWarningMember
 } from '../models/membershipModel';
-import { MembershipRepository } from '../repositories/membershipRepository';
+import { MembershipRepository } from '../repositories';
 import { MembershipPlan, UserMembership } from '../types/membership';
 import { getDaysBetween, formatDateToString } from '../utils/dateUtils';
 import { RevenueService } from './revenueService';

--- a/src/services/noticeService.ts
+++ b/src/services/noticeService.ts
@@ -1,102 +1,6 @@
-import {
-  addDoc,
-  collection,
-  deleteDoc,
-  doc,
-  getDocs,
-  limit,
-  orderBy,
-  query,
-  serverTimestamp,
-  Timestamp,
-  updateDoc
-} from 'firebase/firestore';
-import { db } from '../config/firebase';
-import { serverRead, serverWrite } from '../data/apiClient';
-import { ServerNoticeRepository } from '../repositories/server/serverNoticeRepository';
+import { NoticeAuthor, NoticePost, NoticeRepository } from '../repositories';
 
-export interface NoticePost {
-  id: string;
-  title: string;
-  content: string;
-  authorName: string;
-  createdAtText: string;
-  commentCount: number;
-}
-
-export interface NoticeAuthor {
-  authorName: string;
-  authorEmail: string;
-}
-
-interface FirestoreNoticeDoc {
-  title?: string;
-  postTitle?: string;
-  content?: string;
-  authorName?: string;
-  authorEmail?: string;
-  createdAt?: unknown;
-  commentCount?: number;
-  comments?: unknown[];
-}
-
-const formatDate = (value: unknown): string => {
-  if (!value) return '-';
-
-  let parsedDate: Date | null = null;
-
-  if (value instanceof Date) {
-    parsedDate = value;
-  } else if (value instanceof Timestamp) {
-    parsedDate = value.toDate();
-  } else if (
-    typeof value === 'object' &&
-    value !== null &&
-    'toDate' in value &&
-    typeof (value as { toDate: () => Date }).toDate === 'function'
-  ) {
-    parsedDate = (value as { toDate: () => Date }).toDate();
-  }
-
-  if (!parsedDate) return '-';
-
-  return parsedDate
-    .toLocaleDateString('ko-KR', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit'
-    })
-    .replace(/\s/g, '')
-    .replace(/\.$/, '');
-};
-
-const mapServerToNoticePost = (s: import('../repositories/server/serverNoticeRepository').ServerNoticeResponse): NoticePost => ({
-  id: s.id,
-  title: s.title || '(제목 없음)',
-  content: s.content || '',
-  authorName: s.author_name || '-',
-  createdAtText: formatDate(s.created_at ? new Date(s.created_at) : null),
-  commentCount: s.comment_count
-});
-
-const mapDocToNoticePost = (docSnap: { id: string; data: () => FirestoreNoticeDoc }): NoticePost => {
-  const data = docSnap.data();
-  const commentCount =
-    typeof data.commentCount === 'number'
-      ? data.commentCount
-      : Array.isArray(data.comments)
-        ? data.comments.length
-        : 0;
-
-  return {
-    id: docSnap.id,
-    title: data.title || data.postTitle || '(제목 없음)',
-    content: data.content || '',
-    authorName: data.authorName || '-',
-    createdAtText: formatDate(data.createdAt),
-    commentCount
-  };
-};
+export type { NoticePost, NoticeAuthor };
 
 export class NoticeService {
   static async createNoticePost(
@@ -104,98 +8,26 @@ export class NoticeService {
     payload: { title: string; content: string },
     author?: NoticeAuthor
   ): Promise<void> {
-    if (!boxName) {
-      throw new Error('박스 이름이 없습니다.');
-    }
-
+    if (!boxName) throw new Error('박스 이름이 없습니다.');
     const title = payload.title.trim();
     const content = payload.content.trim();
-
-    if (!title) {
-      throw new Error('공지 제목을 입력해주세요.');
-    }
-
+    if (!title) throw new Error('공지 제목을 입력해주세요.');
     const authorName = author?.authorName?.trim();
-    if (!authorName) {
-      throw new Error('작성자를 입력해주세요.');
-    }
-
-    const now = new Date().toISOString();
-    const docRef = await addDoc(collection(db, `box/${boxName}/notices`), {
-      title,
-      content,
+    if (!authorName) throw new Error('작성자를 입력해주세요.');
+    await NoticeRepository.create(boxName, { title, content }, {
       authorName,
-      authorEmail: author?.authorEmail || '',
-      commentCount: 0,
-      comments: [],
-      createdAt: serverTimestamp(),
-      updatedAt: serverTimestamp()
+      authorEmail: author!.authorEmail || '',
     });
-
-    serverWrite(
-      () => ServerNoticeRepository.createNotice({
-        id: docRef.id,
-        box_name: boxName,
-        title,
-        content,
-        author_name: authorName,
-        author_email: author?.authorEmail || null,
-        created_at: now,
-        updated_at: now
-      }),
-      `Notice.create(${docRef.id})`
-    );
   }
 
   static async getNoticePosts(boxName: string): Promise<NoticePost[]> {
     if (!boxName) return [];
-
-    const serverPosts = await serverRead(
-      async () => {
-        const list = await ServerNoticeRepository.listByBox(boxName, 200);
-        return list.map(mapServerToNoticePost);
-      },
-      `Notice.getNoticePosts(${boxName})`
-    );
-    if (serverPosts && serverPosts.length > 0) return serverPosts;
-
-    try {
-      const noticesQuery = query(
-        collection(db, `box/${boxName}/notices`),
-        orderBy('createdAt', 'desc')
-      );
-      const snapshot = await getDocs(noticesQuery);
-      return snapshot.docs.map((docSnap) => mapDocToNoticePost(docSnap));
-    } catch (error) {
-      console.error('Failed to load notice posts:', error);
-      return [];
-    }
+    return NoticeRepository.list(boxName);
   }
 
   static async getRecentNoticePosts(boxName: string, count = 3): Promise<NoticePost[]> {
     if (!boxName) return [];
-
-    const serverPosts = await serverRead(
-      async () => {
-        const list = await ServerNoticeRepository.listByBox(boxName, count);
-        return list.map(mapServerToNoticePost);
-      },
-      `Notice.getRecentNoticePosts(${boxName})`
-    );
-    if (serverPosts && serverPosts.length > 0) return serverPosts;
-
-    try {
-      const noticesQuery = query(
-        collection(db, `box/${boxName}/notices`),
-        orderBy('createdAt', 'desc'),
-        limit(count)
-      );
-      const snapshot = await getDocs(noticesQuery);
-      return snapshot.docs.map((docSnap) => mapDocToNoticePost(docSnap));
-    } catch (error) {
-      console.error('Failed to load recent notice posts:', error);
-      return [];
-    }
+    return NoticeRepository.list(boxName, count);
   }
 
   static async updateNoticePost(
@@ -203,50 +35,17 @@ export class NoticeService {
     noticeId: string,
     payload: { title: string; content: string; authorName: string }
   ): Promise<void> {
-    if (!boxName) {
-      throw new Error('박스 이름이 없습니다.');
-    }
-
+    if (!boxName) throw new Error('박스 이름이 없습니다.');
     const title = payload.title.trim();
     const content = payload.content.trim();
     const authorName = payload.authorName.trim();
-
-    if (!title) {
-      throw new Error('공지 제목을 입력해주세요.');
-    }
-
-    if (!authorName) {
-      throw new Error('작성자를 입력해주세요.');
-    }
-
-    const now = new Date().toISOString();
-    await updateDoc(doc(db, `box/${boxName}/notices`, noticeId), {
-      title,
-      content,
-      authorName,
-      updatedAt: serverTimestamp()
-    });
-
-    serverWrite(
-      () => ServerNoticeRepository.updateNotice(noticeId, {
-        title,
-        content,
-        author_name: authorName,
-        updated_at: now
-      }),
-      `Notice.update(${noticeId})`
-    );
+    if (!title) throw new Error('공지 제목을 입력해주세요.');
+    if (!authorName) throw new Error('작성자를 입력해주세요.');
+    await NoticeRepository.update(boxName, noticeId, { title, content, authorName });
   }
 
   static async deleteNoticePost(boxName: string, noticeId: string): Promise<void> {
-    if (!boxName) {
-      throw new Error('박스 이름이 없습니다.');
-    }
-
-    await deleteDoc(doc(db, `box/${boxName}/notices`, noticeId));
-    serverWrite(
-      () => ServerNoticeRepository.deleteNotice(noticeId),
-      `Notice.delete(${noticeId})`
-    );
+    if (!boxName) throw new Error('박스 이름이 없습니다.');
+    await NoticeRepository.delete(boxName, noticeId);
   }
 }

--- a/src/services/noticeService.ts
+++ b/src/services/noticeService.ts
@@ -12,6 +12,8 @@ import {
   updateDoc
 } from 'firebase/firestore';
 import { db } from '../config/firebase';
+import { serverRead, serverWrite } from '../data/apiClient';
+import { ServerNoticeRepository } from '../repositories/server/serverNoticeRepository';
 
 export interface NoticePost {
   id: string;
@@ -43,7 +45,9 @@ const formatDate = (value: unknown): string => {
 
   let parsedDate: Date | null = null;
 
-  if (value instanceof Timestamp) {
+  if (value instanceof Date) {
+    parsedDate = value;
+  } else if (value instanceof Timestamp) {
     parsedDate = value.toDate();
   } else if (
     typeof value === 'object' &&
@@ -65,6 +69,15 @@ const formatDate = (value: unknown): string => {
     .replace(/\s/g, '')
     .replace(/\.$/, '');
 };
+
+const mapServerToNoticePost = (s: import('../repositories/server/serverNoticeRepository').ServerNoticeResponse): NoticePost => ({
+  id: s.id,
+  title: s.title || '(제목 없음)',
+  content: s.content || '',
+  authorName: s.author_name || '-',
+  createdAtText: formatDate(s.created_at ? new Date(s.created_at) : null),
+  commentCount: s.comment_count
+});
 
 const mapDocToNoticePost = (docSnap: { id: string; data: () => FirestoreNoticeDoc }): NoticePost => {
   const data = docSnap.data();
@@ -107,7 +120,8 @@ export class NoticeService {
       throw new Error('작성자를 입력해주세요.');
     }
 
-    await addDoc(collection(db, `box/${boxName}/notices`), {
+    const now = new Date().toISOString();
+    const docRef = await addDoc(collection(db, `box/${boxName}/notices`), {
       title,
       content,
       authorName,
@@ -117,17 +131,39 @@ export class NoticeService {
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp()
     });
+
+    serverWrite(
+      () => ServerNoticeRepository.createNotice({
+        id: docRef.id,
+        box_name: boxName,
+        title,
+        content,
+        author_name: authorName,
+        author_email: author?.authorEmail || null,
+        created_at: now,
+        updated_at: now
+      }),
+      `Notice.create(${docRef.id})`
+    );
   }
 
   static async getNoticePosts(boxName: string): Promise<NoticePost[]> {
-    try {
-      if (!boxName) return [];
+    if (!boxName) return [];
 
+    const serverPosts = await serverRead(
+      async () => {
+        const list = await ServerNoticeRepository.listByBox(boxName, 200);
+        return list.map(mapServerToNoticePost);
+      },
+      `Notice.getNoticePosts(${boxName})`
+    );
+    if (serverPosts && serverPosts.length > 0) return serverPosts;
+
+    try {
       const noticesQuery = query(
         collection(db, `box/${boxName}/notices`),
         orderBy('createdAt', 'desc')
       );
-
       const snapshot = await getDocs(noticesQuery);
       return snapshot.docs.map((docSnap) => mapDocToNoticePost(docSnap));
     } catch (error) {
@@ -137,15 +173,23 @@ export class NoticeService {
   }
 
   static async getRecentNoticePosts(boxName: string, count = 3): Promise<NoticePost[]> {
-    try {
-      if (!boxName) return [];
+    if (!boxName) return [];
 
+    const serverPosts = await serverRead(
+      async () => {
+        const list = await ServerNoticeRepository.listByBox(boxName, count);
+        return list.map(mapServerToNoticePost);
+      },
+      `Notice.getRecentNoticePosts(${boxName})`
+    );
+    if (serverPosts && serverPosts.length > 0) return serverPosts;
+
+    try {
       const noticesQuery = query(
         collection(db, `box/${boxName}/notices`),
         orderBy('createdAt', 'desc'),
         limit(count)
       );
-
       const snapshot = await getDocs(noticesQuery);
       return snapshot.docs.map((docSnap) => mapDocToNoticePost(docSnap));
     } catch (error) {
@@ -175,12 +219,23 @@ export class NoticeService {
       throw new Error('작성자를 입력해주세요.');
     }
 
+    const now = new Date().toISOString();
     await updateDoc(doc(db, `box/${boxName}/notices`, noticeId), {
       title,
       content,
       authorName,
       updatedAt: serverTimestamp()
     });
+
+    serverWrite(
+      () => ServerNoticeRepository.updateNotice(noticeId, {
+        title,
+        content,
+        author_name: authorName,
+        updated_at: now
+      }),
+      `Notice.update(${noticeId})`
+    );
   }
 
   static async deleteNoticePost(boxName: string, noticeId: string): Promise<void> {
@@ -189,5 +244,9 @@ export class NoticeService {
     }
 
     await deleteDoc(doc(db, `box/${boxName}/notices`, noticeId));
+    serverWrite(
+      () => ServerNoticeRepository.deleteNotice(noticeId),
+      `Notice.delete(${noticeId})`
+    );
   }
 }

--- a/src/services/revenueService.ts
+++ b/src/services/revenueService.ts
@@ -162,22 +162,6 @@ export class RevenueService {
   }
 
   /**
-   * 일별 매출 저장 API의 자리만 유지합니다.
-   *
-   * @param dailyRevenue 저장할 일별 매출
-   */
-  static async updateDailyRevenue(dailyRevenue: DailyRevenue): Promise<void> {
-    try {
-      const boxName = this.getBoxName();
-      console.log('TODO: Save daily revenue to Firebase', { boxName, dailyRevenue });
-      await RevenueRepository.updateDailyRevenue(boxName, dailyRevenue);
-    } catch (error) {
-      console.error('Error updating daily revenue:', error);
-      throw new Error('매출 데이터 저장에 실패했습니다.');
-    }
-  }
-
-  /**
    * 회원권 매출 데이터를 저장합니다.
    *
    * @param membership 구매된 회원권

--- a/src/services/revenueService.ts
+++ b/src/services/revenueService.ts
@@ -1,5 +1,5 @@
 import { Timestamp } from 'firebase/firestore';
-import { RevenueRepository } from '../repositories/revenueRepository';
+import { RevenueRepository } from '../repositories';
 import { DailyRevenue, MonthlyRevenue, RevenueData, RevenueStats } from '../types/revenue';
 import { UserMembership } from '../types/membership';
 import { formatDateToString } from '../utils/dateUtils';


### PR DESCRIPTION
## 📝 개요

- **작업 유형:** 기능 추가 / 리팩토링

---

## 🚀 주요 변경 사항

Firebase Firestore 단독 접근 구조를 FastAPI 백엔드와 병행하는 **Hybrid Repository 레이어**로 전환합니다.

### 신규 추가

| 분류 | 파일 |
| :--- | :--- |
| **API 클라이언트** | `src/data/apiClient.ts`, `src/data/apiConfig.ts` |
| **Server Repository** (10개) | box, adminBox, class, locker, member, membership, notice, revenue, applied, user, coachMemo |
| **Hybrid Repository** (9개) | box, adminBox, class, locker, member, membership, notice, revenue, coachMemo |
| **Firebase Repository** (2개) | `noticeRepository.ts`, `coachMemoRepository.ts` |

### 핵심 패턴

- **읽기 (server-first):** `serverRead()` → 서버 성공 시 반환, 실패/타임아웃 시 Firestore fallback
- **쓰기 (dual-write):** Firebase 기록 완료 후 서버에 fire-and-forget 동기화 (`serverWrite()`)

### 서비스 레이어 정리

| 파일 | 변경 내용 |
| :--- | :--- |
| `noticeService.ts` | Firestore/apiClient 직접 의존 제거, Repository 위임으로 간소화 |
| `dashboardMemoService.ts` | 동일 — Firestore 직접 호출 제거 |
| `classService.ts`, `revenueService.ts` 등 | Repository 인터페이스로 통일 |

### Dead code 제거

- `classRepository.ts` 미사용 코드 제거
- `revenueRepository.ts` `updateDailyRevenue` no-op 스텁 전체 제거 (서비스 → 훅 호출 체인 전체)

### 버그 수정

- 서버 응답 `joined_at`(ISO 문자열)을 Firestore `Timestamp`로 변환하지 않아 회원 상세보기에서 `toDate is not a function` 에러 발생 → `Timestamp.fromDate(new Date(joined_at))`로 수정

---

## 📊 Before / After

| 구분 | Before | After |
| :--- | :--- | :--- |
| **읽기** | Firestore 단일 소스 | 서버 우선 읽기, 실패 시 Firestore fallback |
| **쓰기** | Firestore만 기록 | Firebase 기록 + 서버 비동기 동기화 |
| **서비스 레이어** | Firestore/apiClient 직접 의존 혼재 | Repository 인터페이스만 사용 |

---

## ✅ 테스트 체크리스트

- [ ] 회원 목록 / 상세보기 정상 동작
- [ ] 공지 CRUD 정상 동작
- [ ] 대시보드 코치 메모 읽기 / 저장
- [ ] 서버 오프라인 시 Firestore fallback 동작

---

## 📎 참고 사항

- `AuthRepository`(signIn/signOut)는 Firebase Auth 전용 — Hybrid 전환 대상 제외
- `adjustMemberCount`는 서버가 members 테이블 COUNT로 자동 산출하므로 별도 API 불필요
- `serverCoachMemoRepository` GET 404는 에러가 아닌 빈 문자열로 처리 (메모 미존재 = 정상 상태)