### PR TITLE
fix: Reject login for non-admin/coach roles

### DIFF
--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -32,9 +32,15 @@ export class AuthService {
   static async login(credentials: LoginCredentials): Promise<User> {
     try {
       const userCredential = await AuthRepository.signIn(credentials);
+      const user = await this.getUserInfo(credentials.email);
+
+      if (user.role !== 'admin' && user.role !== 'coach') {
+        await AuthRepository.signOut();
+        throw new Error('관리자 또는 코치 계정만 로그인할 수 있습니다.');
+      }
+
       const idToken = await userCredential.user.getIdToken();
       const idTokenResult = await userCredential.user.getIdTokenResult();
-      const user = await this.getUserInfo(credentials.email);
 
       localStorage.setItem('userToken', idToken);
       localStorage.setItem('tokenExpiration', idTokenResult.expirationTime);
@@ -44,6 +50,9 @@ export class AuthService {
       return user;
     } catch (error) {
       console.error('Login failed:', error);
+      if (error instanceof Error && error.message === '관리자 또는 코치 계정만 로그인할 수 있습니다.') {
+        throw error;
+      }
       throw new Error('아이디와 비밀번호를 다시 확인해주세요.');
     }
   }


### PR DESCRIPTION
## 📝 개요

- **작업 유형:** 버그 수정

---

## 🚀 주요 변경 사항

> 이번 PR에서 변경된 핵심 내용을 요약해 주세요.

- `AuthService.login()`이 Firebase Authentication 통과 후 `getUserInfo()`로 조회한 사용자 `role`을 추가로 검증하도록 수정
- `role`이 `admin` 또는 `coach`가 아닌 경우 Firebase 세션을 즉시 `signOut` 처리하고 에러(`관리자 또는 코치 계정만 로그인할 수 있습니다.`)를 던지도록 변경
- 토큰 발급 및 `localStorage` 저장 로직을 role 검증 통과 이후로 순서 조정 (검증 실패 시 불필요한 토큰 발급/저장 방지)

---

## 📊 성과 및 결과 (Before / After)

> 변경 전후를 비교해주세요.

| 구분 | 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- | :--- |
| **로그인 로직** | Firebase Auth만 통과하면 role과 무관하게 로그인 성공 → 일반 회원도 인증 세션 생성되어 관리자 메뉴 일부 노출 | Firebase Auth 통과 후 role이 `admin`/`coach`가 아니면 즉시 로그아웃 처리 및 로그인 실패 |

---

## ✅ 테스트 체크리스트

- [x] `tsc --noEmit` 타입 체크 통과
- [ ] 로컬 환경에서 관리자/코치 계정 로그인 정상 동작 확인
- [ ] 로컬 환경에서 일반 회원 계정 로그인 시 실패 및 에러 메시지 노출 확인

---

## 📎 참고 사항

> 리뷰어가 알아야 할 추가 정보나 주의사항을 작성해 주세요.

- 관련 이슈: SWEAT-1 (로그인 시 role 검증 누락 - 일반 회원이 관리자 메뉴 접근 가능)
- 관련 파일: `src/services/authService.ts`(수정), `src/contexts/AuthContext.tsx`/`src/components/AdminProtectedRoute.tsx`(로그인 자체가 막히므로 별도 수정 없음)